### PR TITLE
Use subcommands for common actions on the client

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -88,118 +88,127 @@ func main() {
 			},
 		},
 		{
-			Name:    "list-instances",
+			Name:    "instances",
 			Aliases: []string{},
-			Usage:   "list your instances",
-			Action: func(c *cli.Context) error {
-				instances, err := client.ListInstances()
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-				for _, instance := range instances {
-					fmt.Println(InstanceToString(instance))
-				}
-				return nil
+			Usage:   "manage your instances",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Usage: "list your instances",
+					Action: func(c *cli.Context) error {
+						instances, err := client.ListInstances()
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+						for _, instance := range instances {
+							fmt.Println(InstanceToString(instance))
+						}
+						return nil
+					},
+				},
+				{
+					Name:  "create",
+					Usage: "create a new instance",
+					Action: func(c *cli.Context) error {
+						id := c.Args().First()
+						if id == "" {
+							fmt.Println("error: must supply an image id")
+							return nil
+						}
+
+						image, err := client.GetImage(id)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+
+						instance, err := client.CreateInstance(image)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+
+						fmt.Println("Created")
+						fmt.Println(InstanceToString(instance))
+						return nil
+					},
+				},
+				{
+					Name: "destroy",
+					Usage: "destroy an instance",
+					Action: func(c *cli.Context) error {
+						id := c.Args().First()
+						if id == "" {
+							fmt.Println("error: must supply an instance id")
+							return nil
+						}
+
+						instance, err := client.GetInstance(id)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+
+						err = client.DestroyInstance(instance)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+
+						fmt.Printf("Destroyed %d\n", instance.ID)
+						return nil
+					},
+				},
 			},
 		},
 		{
-			Name:    "list-images",
+			Name:    "images",
 			Aliases: []string{},
-			Usage:   "list your images",
-			Action: func(c *cli.Context) error {
-				images, err := client.ListImages()
+			Usage:   "manage images",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Usage: "list available images",
+					Action: func(c *cli.Context) error {
+						images, err := client.ListImages()
 
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-				for _, image := range images {
-					fmt.Println(ImageToString(image))
-				}
-				return nil
-			},
-		},
-		{
-			Name:    "create-instance",
-			Aliases: []string{},
-			Usage:   "create a new instance",
-			Action: func(c *cli.Context) error {
-				id := c.Args().First()
-				if id == "" {
-					fmt.Println("error: must supply an image id")
-					return nil
-				}
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
+						for _, image := range images {
+							fmt.Println(ImageToString(image))
+						}
+						return nil
+					},
+				},
+				{
+					Name:  "destroy",
+					Usage: "destroy an image",
+					Action: func(c *cli.Context) error {
+						id := c.Args().First()
+						if id == "" {
+							fmt.Println("error: must supply an image id")
+							return nil
+						}
 
-				image, err := client.GetImage(id)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
+						image, err := client.GetImage(id)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
 
-				instance, err := client.CreateInstance(image)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
+						err = client.DestroyImage(image)
+						if err != nil {
+							fmt.Printf("error: %s\n", err)
+							return err
+						}
 
-				fmt.Println("Created")
-				fmt.Println(InstanceToString(instance))
-				return nil
-			},
-		},
-		{
-			Name:    "destroy-instance",
-			Aliases: []string{},
-			Usage:   "destroy an instance",
-			Action: func(c *cli.Context) error {
-				id := c.Args().First()
-				if id == "" {
-					fmt.Println("error: must supply an instance id")
-					return nil
-				}
-
-				instance, err := client.GetInstance(id)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-
-				err = client.DestroyInstance(instance)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-
-				fmt.Printf("Destroyed %d\n", instance.ID)
-				return nil
-			},
-		},
-		{
-			Name:    "destroy-image",
-			Aliases: []string{},
-			Usage:   "destroy an image",
-			Action: func(c *cli.Context) error {
-				id := c.Args().First()
-				if id == "" {
-					fmt.Println("error: must supply an image id")
-					return nil
-				}
-
-				image, err := client.GetImage(id)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-
-				err = client.DestroyImage(image)
-				if err != nil {
-					fmt.Printf("error: %s\n", err)
-					return err
-				}
-
-				fmt.Printf("Destroyed %d\n", image.ID)
-				return nil
+						fmt.Printf("Destroyed %d\n", image.ID)
+						return nil
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
<3 your work on this so far!

I found the client interface a little weird so wanted to suggest this tiny change to tidy it up. The common actions on a resource type (such as `list-images` and `destroy-image`) are now subcommands for the resource, e.g. `images list` and `images destroy`:

```
❯ ./draupnir-client images
NAME:
   draupnir images - manage images

USAGE:
   draupnir images command [command options] [arguments...]

COMMANDS:
     list     list available images
     destroy  destroy an image

OPTIONS:
   --help, -h  show help
```