### PR TITLE
Include PGPASSWORD in env

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -228,7 +228,7 @@ func main() {
 					return err
 				}
 
-				fmt.Printf("export PGHOST=%s PGPORT=%d PGUSER=postgres\n", CONFIG.Domain, instance.Port)
+				fmt.Printf("export PGHOST=%s PGPORT=%d PGUSER=postgres PGPASSWORD=''\n", CONFIG.Domain, instance.Port)
 
 				return nil
 			},


### PR DESCRIPTION
We've already configured the database to have an empty-string user
password, so include this in the environment in case applications expect
such an environment to be present.