### PR TITLE
Parameterise the trusted email domain

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,6 @@ suites:
       - recipe[draupnir::default]
     attributes:
       draupnir:
-        port: 8080
+        port: 8443
         install_from_local_package: true
         local_package_path: /vagrant/draupnir_1.0.0_amd64.deb

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES
     path: tmp/cookbooks/draupnir/berks-cookbooks/sudo
 
 GRAPH
-  draupnir (0.1.0)
+  draupnir (0.1.1)
     iptables-ng (~> 2.2.8)
     sudo (~> 2.2.2)
   iptables-ng (2.2.11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Allow the trusted email domain to be specified via an environment variable.
+
 1.0.0
 -----
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -24,8 +24,9 @@ type Authenticator interface {
 }
 
 type GoogleAuthenticator struct {
-	OAuthClient  OAuthClient
-	SharedSecret string
+	OAuthClient            OAuthClient
+	SharedSecret           string
+	TrustedUserEmailDomain string
 }
 
 func (g GoogleAuthenticator) AuthenticateRequest(r *http.Request) (string, error) {
@@ -45,7 +46,7 @@ func (g GoogleAuthenticator) AuthenticateRequest(r *http.Request) (string, error
 		return "", fmt.Errorf("Error looking up access token: %s", err.Error())
 	}
 
-	if !strings.HasSuffix(email, "@gocardless.com") {
+	if !strings.HasSuffix(email, g.TrustedUserEmailDomain) {
 		return "", errors.New("Email not valid")
 	}
 

--- a/chef/data_bags/draupnir_enc/draupnir_user.json
+++ b/chef/data_bags/draupnir_enc/draupnir_user.json
@@ -5,5 +5,6 @@
   "oauth_client_secret": "the_client_secret",
   "oauth_redirect_url": "https://server.com/oauth_callback",
   "tls_certificate_path": "/etc/ssl/certs/draupnir_cert.pem",
-  "tls_private_key_path": "/etc/ssl/certs/draupnir_key.pem"
+  "tls_private_key_path": "/etc/ssl/certs/draupnir_key.pem",
+  "trusted_user_email_domain": "@gocardless.com"
 }

--- a/main.go
+++ b/main.go
@@ -19,16 +19,17 @@ import (
 )
 
 type Config struct {
-	Port               int    `required:"true"`
-	DatabaseUrl        string `required:"true" split_words:"true"`
-	DataPath           string `required:"true" split_words:"true"`
-	Environment        string `required:"false"`
-	SharedSecret       string `required:"true" split_words:"true"`
-	OauthRedirectUrl   string `required:"true" split_words:"true"`
-	OauthClientId      string `required:"true" split_words:"true"`
-	OauthClientSecret  string `required:"true" split_words:"true"`
-	TlsCertificatePath string `required:"true" split_words:"true"`
-	TlsPrivateKeyPath  string `required:"true" split_words:"true"`
+	Port                   int    `required:"true"`
+	DatabaseUrl            string `required:"true" split_words:"true"`
+	DataPath               string `required:"true" split_words:"true"`
+	Environment            string `required:"false"`
+	SharedSecret           string `required:"true" split_words:"true"`
+	OauthRedirectUrl       string `required:"true" split_words:"true"`
+	OauthClientId          string `required:"true" split_words:"true"`
+	OauthClientSecret      string `required:"true" split_words:"true"`
+	TlsCertificatePath     string `required:"true" split_words:"true"`
+	TlsPrivateKeyPath      string `required:"true" split_words:"true"`
+	TrustedUserEmailDomain string `required:"true" split_words:"true"`
 }
 
 func main() {
@@ -57,8 +58,9 @@ func main() {
 	executor := exec.OSExecutor{DataPath: c.DataPath}
 
 	authenticator := auth.GoogleAuthenticator{
-		OAuthClient:  auth.GoogleOAuthClient{Config: &oauthConfig},
-		SharedSecret: c.SharedSecret,
+		OAuthClient:            auth.GoogleOAuthClient{Config: &oauthConfig},
+		SharedSecret:           c.SharedSecret,
+		TrustedUserEmailDomain: c.TrustedUserEmailDomain,
 	}
 	if c.Environment == "test" {
 		authenticator.OAuthClient = auth.FakeOAuthClient{}


### PR DESCRIPTION
Allow users to specify the "trusted" domain via an environment variable.
This is the domain that we'll require user email addresses to have in
order to authenticate them successfully.

Depends on https://github.com/gocardless/chef-draupnir/pull/8