### PR TITLE
Semver match on Draupnir-Version header

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,11 +59,6 @@ func (c Client) get(url string) (*http.Response, error) {
 		return response, err
 	}
 
-	apiVersion := response.Header.Get("Draupnir-Version")
-	if apiVersion != version.Version {
-		return response, fmt.Errorf("the API version (%s) does not match your client's version (%s). You may need to update your client", apiVersion, version.Version)
-	}
-
 	return response, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func main() {
 		Add(routes.LogRequest).
 		Add(withVersion).
 		Add(asJSON).
-		Add(routes.CheckAPIVersion).
+		Add(routes.CheckAPIVersion(version.Version)).
 		ToMiddleware()
 
 	chain.

--- a/routes/check_api_version.go
+++ b/routes/check_api_version.go
@@ -7,23 +7,30 @@ import (
 )
 
 // CheckAPIVersion checks that the request has a Draupnir-Version header with a
-// version that matches the server's version.
+// version that matches the server's major version, and is equal to or lower
+// than the minor version.
+//
 // If the version doesn't match or the header is missing, it renders a 400 Bad
-// Request
-func CheckAPIVersion(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		versions := r.Header["Draupnir-Version"]
-		if len(versions) == 0 {
-			RenderError(w, http.StatusBadRequest, missingApiVersion)
-			return
-		}
+// Request.
+func CheckAPIVersion(serverVersion string) func(http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			versions := r.Header["Draupnir-Version"]
+			if len(versions) == 0 {
+				RenderError(w, http.StatusBadRequest, missingApiVersion)
+				return
+			}
 
-		requestVersion := versions[0]
-		if requestVersion != version.Version {
-			RenderError(w, http.StatusBadRequest, invalidApiVersion(requestVersion))
-			return
-		}
+			requestVersion := versions[0]
+			requestMajor, requestMinor, _ := version.ParseSemver(requestVersion)
+			major, minor, _ := version.ParseSemver(serverVersion)
 
-		next(w, r)
+			if major != requestMajor || minor < requestMinor {
+				RenderError(w, http.StatusBadRequest, invalidApiVersion(requestVersion))
+				return
+			}
+
+			next(w, r)
+		}
 	}
 }

--- a/routes/check_api_version_test.go
+++ b/routes/check_api_version_test.go
@@ -9,40 +9,58 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func shouldNeverBeCalled(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, h *http.Request) {
+		t.Fatal("this route should never be called")
+	}
+}
+
+func respondsWithStatus(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, h *http.Request) {
+		w.WriteHeader(status)
+	}
+}
+
 func TestCheckApiVersion(t *testing.T) {
 	testCases := []struct {
 		name          string
 		headerVersion string
+		handler       http.HandlerFunc
 		apiError      APIError
 		code          int
 	}{
 		{
 			"when version matches, calls handler",
 			"1.1.0",
+			respondsWithStatus(http.StatusAccepted),
 			APIError{},
 			http.StatusAccepted,
 		},
 		{
 			"when minor is lower, calls handler",
 			"1.0.0",
+			respondsWithStatus(http.StatusAccepted),
 			APIError{},
 			http.StatusAccepted,
 		},
 		{
 			"when minor is higher, responds with error",
 			"1.2.0",
+			shouldNeverBeCalled(t),
 			invalidApiVersion("1.2.0"),
 			http.StatusBadRequest,
 		},
 		{
 			"when header major version is different, responds with error",
 			"0.1.0",
+			shouldNeverBeCalled(t),
 			invalidApiVersion("0.1.0"),
 			http.StatusBadRequest,
 		},
 		{
 			"when header is missing, responds with error",
 			"",
+			shouldNeverBeCalled(t),
 			missingApiVersion,
 			http.StatusBadRequest,
 		},
@@ -57,15 +75,7 @@ func TestCheckApiVersion(t *testing.T) {
 				req.Header["Draupnir-Version"] = []string{tc.headerVersion}
 			}
 
-			CheckAPIVersion("1.1.0")(
-				func(w http.ResponseWriter, h *http.Request) {
-					if tc.apiError.ID != "" {
-						t.Fatal("this route should never be called")
-					}
-
-					w.WriteHeader(http.StatusAccepted)
-				},
-			)(recorder, req)
+			CheckAPIVersion("1.1.0")(tc.handler)(recorder, req)
 
 			if tc.apiError.ID != "" {
 				var response APIError

--- a/spec/draupnir/health_check_spec.rb
+++ b/spec/draupnir/health_check_spec.rb
@@ -9,5 +9,20 @@ RSpec.describe "/health_check" do
     expect(JSON.parse(response.body)).to eq("status" => "ok")
     expect(response.headers[:content_type]).to eq("application/json")
     expect(response.headers[:draupnir_version]).to eq(Draupnir::VERSION)
+
+    # Verify that we have a well-formed version, ie. valid semver value
+    expect(response.headers[:draupnir_version]).not_to eql("0.0.0")
+    expect(response.headers[:draupnir_version]).to match(/^\d+\.\d+\.\d+$/)
+  end
+
+  context "with old client version" do
+    it "responds with 'Bad Request'" do
+      begin
+        client.request(:get, "/images", nil, draupnir_version: "0.0.0")
+        raise "didn't throw 400 Bad Request"
+      rescue RestClient::BadRequest => err
+        expect(err.http_code).to be(400)
+      end
+    end
   end
 end

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -11,13 +12,13 @@ import (
 var Version string
 
 // ParseSemver extracts the major minor and patch level versions from a version string.
-func ParseSemver(version string) (int, int, int) {
-	if !regexp.MustCompile("^\\d+\\.\\d+\\.\\d+$").Match([]byte(version)) {
-		return -1, -1, -1
+func ParseSemver(version string) (int, int, int, error) {
+	if !regexp.MustCompile("^\\d+\\.\\d+\\.\\d+$").MatchString(version) {
+		return -1, -1, -1, fmt.Errorf("version was not a valid semver: %s", version)
 	}
 
 	mustAtoi := func(s string) int { i, _ := strconv.Atoi(s); return i }
 
 	components := strings.Split(version, ".")
-	return mustAtoi(components[0]), mustAtoi(components[1]), mustAtoi(components[2])
+	return mustAtoi(components[0]), mustAtoi(components[1]), mustAtoi(components[2]), nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,23 @@
 package version
 
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
 // Version specifies the current version of Draupnir
 // This value is injected in at compile time (see the Makefile)
 var Version string
+
+// ParseSemver extracts the major minor and patch level versions from a version string.
+func ParseSemver(version string) (int, int, int) {
+	if !regexp.MustCompile("^\\d+\\.\\d+\\.\\d+$").Match([]byte(version)) {
+		return -1, -1, -1
+	}
+
+	mustAtoi := func(s string) int { i, _ := strconv.Atoi(s); return i }
+
+	components := strings.Split(version, ".")
+	return mustAtoi(components[0]), mustAtoi(components[1]), mustAtoi(components[2])
+}


### PR DESCRIPTION
Only reject requests that come from clients that are newer than the
server, or are running a different major version. This should be totally
fine as per semver rules, and will provide more flexibility to upgrade
the server without breaking clients.

The client also now doesn't inject an error if the server version
mismatches, and leaves the check up to the server. The API will return
an error that would otherwise be rendered, so we don't need to duplicate
the check in the client.