### PR TITLE
Support image create/finalise in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/oauth2"
 
@@ -240,6 +241,50 @@ func (c Client) DestroyInstance(instance models.Instance) error {
 	}
 
 	return nil
+}
+
+type createImageRequest struct {
+	BackedUpAt time.Time `jsonapi:"attr,backed_up_at,iso8601"`
+	Anon       string    `jsonapi:"attr,anonymisation_script"`
+}
+
+// CreateImage creates a new image. This does not complete the process of preparing an
+// image, subsequent upload and finalisation steps are required.
+func (c Client) CreateImage(backedUpAt time.Time, anon []byte) (models.Image, error) {
+	var image models.Image
+	request := createImageRequest{BackedUpAt: backedUpAt, Anon: string(anon)}
+
+	var payload bytes.Buffer
+	err := jsonapi.MarshalOnePayloadWithoutIncluded(&payload, &request)
+	if err != nil {
+		return image, err
+	}
+
+	resp, err := c.post(fmt.Sprintf("%s/images", c.URL), &payload)
+	if err != nil {
+		return image, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return image, parseError(resp.Body)
+	}
+
+	err = jsonapi.UnmarshalPayload(resp.Body, &image)
+	return image, err
+}
+
+// FinaliseImage posts to images/id/done, causing draupnir to run the finalisation process
+// to anonymise and prepare the image for usage.
+func (c Client) FinaliseImage(imageID int) (models.Image, error) {
+	var image models.Image
+	var emptyPayload bytes.Buffer
+
+	resp, err := c.post(fmt.Sprintf("%s/images/%d/done", c.URL, imageID), &emptyPayload)
+	if err != nil {
+		err = jsonapi.UnmarshalPayload(resp.Body, &image)
+	}
+
+	return image, err
 }
 
 // DestroyImage destroys an image

--- a/client/client.go
+++ b/client/client.go
@@ -200,14 +200,10 @@ func (c Client) ListInstances() ([]models.Instance, error) {
 	return instances, nil
 }
 
-type createInstanceRequest struct {
-	ImageID string `jsonapi:"attr,image_id"`
-}
-
 // CreateInstance creates a new instance
 func (c Client) CreateInstance(image models.Image) (models.Instance, error) {
 	var instance models.Instance
-	request := createInstanceRequest{ImageID: strconv.Itoa(image.ID)}
+	request := routes.CreateInstanceRequest{ImageID: strconv.Itoa(image.ID)}
 
 	var payload bytes.Buffer
 	err := jsonapi.MarshalOnePayloadWithoutIncluded(&payload, &request)
@@ -243,16 +239,11 @@ func (c Client) DestroyInstance(instance models.Instance) error {
 	return nil
 }
 
-type createImageRequest struct {
-	BackedUpAt time.Time `jsonapi:"attr,backed_up_at,iso8601"`
-	Anon       string    `jsonapi:"attr,anonymisation_script"`
-}
-
 // CreateImage creates a new image. This does not complete the process of preparing an
 // image, subsequent upload and finalisation steps are required.
 func (c Client) CreateImage(backedUpAt time.Time, anon []byte) (models.Image, error) {
 	var image models.Image
-	request := createImageRequest{BackedUpAt: backedUpAt, Anon: string(anon)}
+	request := routes.CreateImageRequest{BackedUpAt: backedUpAt, Anon: string(anon)}
 
 	var payload bytes.Buffer
 	err := jsonapi.MarshalOnePayloadWithoutIncluded(&payload, &request)

--- a/routes/images.go
+++ b/routes/images.go
@@ -83,7 +83,7 @@ func (i Images) List(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type createImageRequest struct {
+type CreateImageRequest struct {
 	BackedUpAt time.Time `jsonapi:"attr,backed_up_at,iso8601"`
 	Anon       string    `jsonapi:"attr,anonymisation_script"`
 }
@@ -96,7 +96,7 @@ func (i Images) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req := createImageRequest{}
+	req := CreateImageRequest{}
 	if err := jsonapi.UnmarshalPayload(r.Body, &req); err != nil {
 		i.Logger.Info(err.Error())
 		RenderError(w, http.StatusBadRequest, invalidJSONError)

--- a/routes/images_test.go
+++ b/routes/images_test.go
@@ -104,7 +104,7 @@ func TestListImages(t *testing.T) {
 
 func TestCreateImage(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	request := createImageRequest{
+	request := CreateImageRequest{
 		BackedUpAt: timestamp(),
 		Anon:       "SELECT * FROM foo;",
 	}
@@ -159,7 +159,7 @@ func TestImageCreateReturnsErrorWithInvalidPayload(t *testing.T) {
 
 func TestImageCreateReturnsErrorWhenSubvolumeCreationFails(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	request := createImageRequest{
+	request := CreateImageRequest{
 		BackedUpAt: timestamp(),
 		Anon:       "SELECT * FROM foo;",
 	}

--- a/routes/instances.go
+++ b/routes/instances.go
@@ -25,7 +25,7 @@ type Instances struct {
 	Logger        log.Logger
 }
 
-type createInstanceRequest struct {
+type CreateInstanceRequest struct {
 	ImageID string `jsonapi:"attr,image_id"`
 }
 
@@ -37,7 +37,7 @@ func (i Instances) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req := createInstanceRequest{}
+	req := CreateInstanceRequest{}
 	if err := jsonapi.UnmarshalPayload(r.Body, &req); err != nil {
 		i.Logger.Info(err.Error())
 		RenderError(w, http.StatusBadRequest, invalidJSONError)

--- a/routes/instances_test.go
+++ b/routes/instances_test.go
@@ -18,7 +18,7 @@ import (
 func TestInstanceCreate(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	request := createInstanceRequest{ImageID: "1"}
+	request := CreateInstanceRequest{ImageID: "1"}
 	body := bytes.NewBuffer([]byte{})
 	jsonapi.MarshalOnePayload(body, &request)
 	req := httptest.NewRequest("POST", "/instances", body)
@@ -71,7 +71,7 @@ func TestInstanceCreate(t *testing.T) {
 func TestInstanceCreateReturnsErrorWithUnreadyImage(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	request := createInstanceRequest{ImageID: "1"}
+	request := CreateInstanceRequest{ImageID: "1"}
 	body := bytes.NewBuffer([]byte{})
 	jsonapi.MarshalOnePayload(body, &request)
 
@@ -136,7 +136,7 @@ func TestInstanceCreateReturnsErrorWithInvalidPayload(t *testing.T) {
 
 func TestInstanceCreateWithInvalidImageID(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	request := createInstanceRequest{ImageID: "garbage"}
+	request := CreateInstanceRequest{ImageID: "garbage"}
 	body := bytes.NewBuffer([]byte{})
 	jsonapi.MarshalOnePayload(body, &request)
 	logger, output := NewFakeLogger()


### PR DESCRIPTION
If we support creation and finalisation of images from the client then
we can do everything for running draupnir from the one binary.