### PR TITLE
Set OAuth token exchange timeout to 0 in tests

### DIFF
--- a/routes/access_tokens.go
+++ b/routes/access_tokens.go
@@ -138,7 +138,7 @@ func (a AccessTokens) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), TOKEN_EXCHANGE_TIMEOUT)
+	ctx, cancel := context.WithTimeout(r.Context(), TOKEN_EXCHANGE_TIMEOUT)
 	defer cancel()
 	token, err := a.Client.Exchange(ctx, respCode)
 

--- a/routes/access_tokens_test.go
+++ b/routes/access_tokens_test.go
@@ -245,6 +245,10 @@ func TestCallbackWithTimedOutTokenExchange(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Set the request to time out immediately
+	ctx, _ := context.WithTimeout(req.Context(), 0)
+	req = req.WithContext(ctx)
+
 	callback := make(chan OAuthCallback, 1)
 	callbacks := make(map[string]chan OAuthCallback)
 	callbacks[state] = callback


### PR DESCRIPTION
This takes our total test time from 5.05 seconds to 0.05 seconds.