### PR TITLE
Listen on http locally

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,6 +79,12 @@
   revision = "b0d5024adb34b4122c6ee7eeb6ab511f7223222d"
 
 [[projects]]
+  name = "github.com/oklog/run"
+  packages = ["."]
+  revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -159,6 +165,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "21de839bdf11ef105bf498e555515b57b9263ec80da3ab6469104f21e74d5d40"
+  inputs-digest = "e374163937b1bb1f95700292009913db53a4762a50b755cae4a52f06dd14255c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/oklog/run/.gitignore
+++ b/vendor/github.com/oklog/run/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/

--- a/vendor/github.com/oklog/run/.travis.yml
+++ b/vendor/github.com/oklog/run/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+sudo: false
+go:
+  - 1.x
+  - tip
+install:
+  - go get -v github.com/golang/lint/golint
+  - go build ./...
+script:
+  - go vet ./...
+  - $HOME/gopath/bin/golint .
+  - go test -v -race ./...

--- a/vendor/github.com/oklog/run/LICENSE
+++ b/vendor/github.com/oklog/run/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/oklog/run/README.md
+++ b/vendor/github.com/oklog/run/README.md
@@ -1,0 +1,73 @@
+# run
+
+[![GoDoc](https://godoc.org/github.com/oklog/run?status.svg)](https://godoc.org/github.com/oklog/run) 
+[![Build Status](https://travis-ci.org/oklog/run.svg?branch=master)](https://travis-ci.org/oklog/run) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/oklog/run)](https://goreportcard.com/report/github.com/oklog/run)
+[![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/run/master/LICENSE)
+
+run.Group is a universal mechanism to manage goroutine lifecycles.
+
+Create a zero-value run.Group, and then add actors to it. Actors are defined as
+a pair of functions: an **execute** function, which should run synchronously;
+and an **interrupt** function, which, when invoked, should cause the execute
+function to return. Finally, invoke Run, which blocks until the first actor
+returns. This general-purpose API allows callers to model pretty much any
+runnable task, and achieve well-defined lifecycle semantics for the group.
+
+run.Group was written to manage component lifecycles in func main for 
+[OK Log](https://github.com/oklog/oklog). 
+But it's useful in any circumstance where you need to orchestrate multiple
+goroutines as a unit whole.
+[Click here](https://www.youtube.com/watch?v=LHe1Cb_Ud_M&t=15m45s) to see a
+video of a talk where run.Group is described.
+
+## Examples
+
+### context.Context
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+g.Add(func() error {
+	return myProcess(ctx, ...)
+}, func(error) {
+	cancel()
+})
+```
+
+### net.Listener
+
+```go
+ln, _ := net.Listen("tcp", ":8080")
+g.Add(func() error {
+	return http.Serve(ln, nil)
+}, func(error) {
+	ln.Close()
+})
+```
+
+### io.ReadCloser
+
+```go
+var conn io.ReadCloser = ...
+g.Add(func() error {
+	s := bufio.NewScanner(conn)
+	for s.Scan() {
+		println(s.Text())
+	}
+	return s.Err()
+}, func(error) {
+	conn.Close()
+})
+```
+
+## Comparisons
+
+Package run is somewhat similar to package 
+[errgroup](https://godoc.org/golang.org/x/sync/errgroup), 
+except it doesn't require actor goroutines to understand context semantics.
+
+It's somewhat similar to package
+[tomb.v1](https://godoc.org/gopkg.in/tomb.v1) or 
+[tomb.v2](https://godoc.org/gopkg.in/tomb.v2),
+except it has a much smaller API surface, delegating e.g. staged shutdown of 
+goroutines to the caller.

--- a/vendor/github.com/oklog/run/example_test.go
+++ b/vendor/github.com/oklog/run/example_test.go
@@ -1,0 +1,95 @@
+package run_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/oklog/run"
+)
+
+func ExampleGroup_Add_basic() {
+	var g run.Group
+	{
+		cancel := make(chan struct{})
+		g.Add(func() error {
+			select {
+			case <-time.After(time.Second):
+				fmt.Printf("The first actor had its time elapsed\n")
+				return nil
+			case <-cancel:
+				fmt.Printf("The first actor was canceled\n")
+				return nil
+			}
+		}, func(err error) {
+			fmt.Printf("The first actor was interrupted with: %v\n", err)
+			close(cancel)
+		})
+	}
+	{
+		g.Add(func() error {
+			fmt.Printf("The second actor is returning immediately\n")
+			return errors.New("immediate teardown")
+		}, func(err error) {
+			// Note that this interrupt function is called, even though the
+			// corresponding execute function has already returned.
+			fmt.Printf("The second actor was interrupted with: %v\n", err)
+		})
+	}
+	fmt.Printf("The group was terminated with: %v\n", g.Run())
+	// Output:
+	// The second actor is returning immediately
+	// The first actor was interrupted with: immediate teardown
+	// The second actor was interrupted with: immediate teardown
+	// The first actor was canceled
+	// The group was terminated with: immediate teardown
+}
+
+func ExampleGroup_Add_context() {
+	ctx, cancel := context.WithCancel(context.Background())
+	var g run.Group
+	{
+		ctx, cancel := context.WithCancel(ctx) // note: shadowed
+		g.Add(func() error {
+			return runUntilCanceled(ctx)
+		}, func(error) {
+			cancel()
+		})
+	}
+	go cancel()
+	fmt.Printf("The group was terminated with: %v\n", g.Run())
+	// Output:
+	// The group was terminated with: context canceled
+}
+
+func ExampleGroup_Add_listener() {
+	var g run.Group
+	{
+		ln, _ := net.Listen("tcp", ":0")
+		g.Add(func() error {
+			defer fmt.Printf("http.Serve returned\n")
+			return http.Serve(ln, http.NewServeMux())
+		}, func(error) {
+			ln.Close()
+		})
+	}
+	{
+		g.Add(func() error {
+			return errors.New("immediate teardown")
+		}, func(error) {
+			//
+		})
+	}
+	fmt.Printf("The group was terminated with: %v\n", g.Run())
+	// Output:
+	// http.Serve returned
+	// The group was terminated with: immediate teardown
+}
+
+func runUntilCanceled(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/vendor/github.com/oklog/run/group.go
+++ b/vendor/github.com/oklog/run/group.go
@@ -1,0 +1,62 @@
+// Package run implements an actor-runner with deterministic teardown. It is
+// somewhat similar to package errgroup, except it does not require actor
+// goroutines to understand context semantics. This makes it suitable for use in
+// more circumstances; for example, goroutines which are handling connections
+// from net.Listeners, or scanning input from a closable io.Reader.
+package run
+
+// Group collects actors (functions) and runs them concurrently.
+// When one actor (function) returns, all actors are interrupted.
+// The zero value of a Group is useful.
+type Group struct {
+	actors []actor
+}
+
+// Add an actor (function) to the group. Each actor must be pre-emptable by an
+// interrupt function. That is, if interrupt is invoked, execute should return.
+// Also, it must be safe to call interrupt even after execute has returned.
+//
+// The first actor (function) to return interrupts all running actors.
+// The error is passed to the interrupt functions, and is returned by Run.
+func (g *Group) Add(execute func() error, interrupt func(error)) {
+	g.actors = append(g.actors, actor{execute, interrupt})
+}
+
+// Run all actors (functions) concurrently.
+// When the first actor returns, all others are interrupted.
+// Run only returns when all actors have exited.
+// Run returns the error returned by the first exiting actor.
+func (g *Group) Run() error {
+	if len(g.actors) == 0 {
+		return nil
+	}
+
+	// Run each actor.
+	errors := make(chan error, len(g.actors))
+	for _, a := range g.actors {
+		go func(a actor) {
+			errors <- a.execute()
+		}(a)
+	}
+
+	// Wait for the first actor to stop.
+	err := <-errors
+
+	// Signal all actors to stop.
+	for _, a := range g.actors {
+		a.interrupt(err)
+	}
+
+	// Wait for all actors to stop.
+	for i := 1; i < cap(errors); i++ {
+		<-errors
+	}
+
+	// Return the original error.
+	return err
+}
+
+type actor struct {
+	execute   func() error
+	interrupt func(error)
+}

--- a/vendor/github.com/oklog/run/group_test.go
+++ b/vendor/github.com/oklog/run/group_test.go
@@ -1,0 +1,57 @@
+package run_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/oklog/run"
+)
+
+func TestZero(t *testing.T) {
+	var g run.Group
+	res := make(chan error)
+	go func() { res <- g.Run() }()
+	select {
+	case err := <-res:
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout")
+	}
+}
+
+func TestOne(t *testing.T) {
+	myError := errors.New("foobar")
+	var g run.Group
+	g.Add(func() error { return myError }, func(error) {})
+	res := make(chan error)
+	go func() { res <- g.Run() }()
+	select {
+	case err := <-res:
+		if want, have := myError, err; want != have {
+			t.Errorf("want %v, have %v", want, have)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout")
+	}
+}
+
+func TestMany(t *testing.T) {
+	interrupt := errors.New("interrupt")
+	var g run.Group
+	g.Add(func() error { return interrupt }, func(error) {})
+	cancel := make(chan struct{})
+	g.Add(func() error { <-cancel; return nil }, func(error) { close(cancel) })
+	res := make(chan error)
+	go func() { res <- g.Run() }()
+	select {
+	case err := <-res:
+		if want, have := interrupt, err; want != have {
+			t.Errorf("want %v, have %v", want, have)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Errorf("timeout")
+	}
+}


### PR DESCRIPTION
It would be really useful for draupnir to listen on HTTP for connections
from the same box. This enables usage of the draupnir-client locally,
pointing at localhost for the connection, without having issues with
certificates.