### PR TITLE
Optionally unpack tar backup

### DIFF
--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -41,11 +41,19 @@ SNAPSHOT_PATH="${ROOT}/image_snapshots/${ID}"
 
 set -x
 
-sudo mkdir "${UPLOAD_PATH}/tmp"
-sudo sh -c "tar xf ${UPLOAD_PATH}/*.tar* -C ${UPLOAD_PATH}/tmp"
-sudo sh -c "mv ${UPLOAD_PATH}/tmp/* ${UPLOAD_PATH}/"
-sudo rmdir "${UPLOAD_PATH}/tmp"
-sudo sh -c "rm -f ${UPLOAD_PATH}/*.tar*" # remove the compressed backup file(s)
+sudo mkdir -p "${UPLOAD_PATH}/tmp"
+
+if sudo sh -c "ls ${UPLOAD_PATH}/*.tar*"; then
+	sudo sh -c "tar xf ${UPLOAD_PATH}/*.tar* -C ${UPLOAD_PATH}/tmp"
+	sudo sh -c "mv ${UPLOAD_PATH}/tmp/* ${UPLOAD_PATH}/"
+	sudo rmdir "${UPLOAD_PATH}/tmp"
+	sudo sh -c "rm -f ${UPLOAD_PATH}/*.tar*" # remove the compressed backup file(s)
+fi
+
+if ! sudo -u postgres /usr/lib/postgresql/9.4/bin/pg_controldata "${UPLOAD_PATH}"; then
+	echo "image upload is not valid postgresql data directory"
+	exit 255
+fi
 
 sudo rm -f "${UPLOAD_PATH}/postmaster.pid"
 sudo rm -f "${UPLOAD_PATH}/postmaster.opts"


### PR DESCRIPTION
draupnir-finalise-image will currently fail if the upload is not in tar
format. This change allows a user to do their own custom upload of a
draupnir data directory, with whatever preparation step they wish to
perform, by only unpacking a tar file if we find one present.

This becomes really useful for people who wish to do the backup recovery
on the same machine as draupnir, as they can unpack the database and
recover from WAL files all inside the image upload directory.