### PR TITLE
Scope instance list

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -423,5 +423,5 @@ func ImageToString(i models.Image) string {
 }
 
 func InstanceToString(i models.Instance) string {
-	return fmt.Sprintf("%2d [ PORT: %d - %s ]", i.ID, i.Port, i.CreatedAt.Format(time.RFC3339))
+	return fmt.Sprintf("%2d [ IMAGE: %d | PORT: %d - %s ]", i.ID, i.ImageID, i.Port, i.CreatedAt.Format(time.RFC3339))
 }

--- a/routes/fakes.go
+++ b/routes/fakes.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 
+	"github.com/gocardless/draupnir/auth"
 	"github.com/gocardless/draupnir/models"
 )
 
@@ -107,6 +108,12 @@ type AllowAll struct{}
 
 func (a AllowAll) AuthenticateRequest(r *http.Request) (string, error) {
 	return "test@draupnir", nil
+}
+
+type UploadUser struct{}
+
+func (u UploadUser) AuthenticateRequest(r *http.Request) (string, error) {
+	return auth.UPLOAD_USER_EMAIL, nil
 }
 
 type FakeOAuthClient struct {

--- a/routes/instances.go
+++ b/routes/instances.go
@@ -110,10 +110,11 @@ func (i Instances) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build a slice of pointers to our images, because this is what jsonapi wants
-	// At the same time, filter out instances that don't belong to this user
+	// At the same time, filter out instances that don't belong to this user if we're not
+	// using the shared secret.
 	_instances := make([]*models.Instance, 0)
 	for idx, instance := range instances {
-		if instance.UserEmail == email {
+		if auth.UPLOAD_USER_EMAIL == email || instance.UserEmail == email {
 			_instances = append(_instances, &instances[idx])
 		}
 	}


### PR DESCRIPTION
Cleaning up instances is made easier when the upload user can list all
instances on the draupnir instance. This change scopes the instance list
request to show all instances, including in that output the image ID.