### PR TITLE
Set temp_file_limit in postgresql.conf

### DIFF
--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -80,6 +80,7 @@ shared_preload_libraries = 'pg_stat_statements'
 ssl = on
 ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
+temp_file_limit = 5242880 # 5GiB
 work_mem = '128MB'
 hot_standby = 'on'
 wal_level = 'hot_standby'


### PR DESCRIPTION
In future we probably want to provide a sample postgresql.conf when we create images. Right now though, hardcoding a 5GB limit is a Good Thing™

---

Specify a limit on temporary files to ensure a single instances doesn't
consume hundreds of GBs disk space.