### PR TITLE
Improve finalisation performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Unreleased
   at /etc/draupnir/config.toml. Proxy settings are still configured via the
   HTTP_PROXY and HTTPS_PROXY environment variables, but everything else is
   configured using the config file. The format is documented in the README.
+- Vacuum databases by default after the anonymisation step, to avoid the vacuum
+  processes starting in all instances of a draupnir database and causing large
+  amounts of exclusive data to be generated per snapshot
 
 1.7.0
 -----

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -82,8 +82,15 @@ ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
 temp_file_limit = 5242880 # 5GiB
 work_mem = '128MB'
-hot_standby = 'on'
-wal_level = 'hot_standby'
+
+# Turn off hot standby as we won't ever need to run queries against this
+# database while it's in recovery. We also want to reduce- as much as is
+# possible- the amount of WAL we write during finalisation, as this step usually
+# requires a significant amount of IO. Similarly, fsync should be turned off
+# during finalisation.
+hot_standby = 'off'
+wal_level = 'minimal'
+fsync = 'off'
 EOF
 
 # Start postgres
@@ -94,8 +101,12 @@ sudo -u postgres createuser --port="$PORT" -d -r -s draupnir
 
 # Anonymise
 echo "Executing anonymisation script $ANON_FILE"
-sudo cat "$ANON_FILE"
 sudo cat "$ANON_FILE" | sudo -u draupnir "$PSQL" -p "$PORT" --username=draupnir postgres
+
+echo "Turning back on fsync and hot_standby wal level"
+sed -i \
+  "s/wal_level = 'off'/wal_level = 'hot_standby'/; s/fsync = 'off'/fsync = 'on'/" \
+  "${UPLOAD_PATH}/postgresql.conf"
 
 sudo -u postgres $PG_CTL -D "$UPLOAD_PATH" -w stop
 sudo rm -f "${UPLOAD_PATH}/postmaster.pid"

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -27,6 +27,7 @@ if ! [[ "$#" -eq 4 ]]; then
 fi
 
 PG_CTL=/usr/lib/postgresql/9.4/bin/pg_ctl
+VACUUMDB=/usr/lib/postgresql/9.4/bin/vacuumdb
 PSQL=/usr/bin/psql
 
 ROOT=$1
@@ -102,6 +103,17 @@ sudo -u postgres createuser --port="$PORT" -d -r -s draupnir
 # Anonymise
 echo "Executing anonymisation script $ANON_FILE"
 sudo cat "$ANON_FILE" | sudo -u draupnir "$PSQL" -p "$PORT" --username=draupnir postgres
+
+echo "Vacuum all the databases in the cluster"
+sudo -u postgres bash <<BASH
+export PGPORT="$PORT"
+for database in \$(psql -t -c "select datname from pg_database where not datname like 'template%';");
+do
+  echo ">> vacuuming \$database"
+  psql --dbname "\$database" -t -c "select table_name from information_schema.tables where table_schema='public';" \
+    | xargs -P5 -n1 "$VACUUMDB" --dbname "\$database" --table
+done
+BASH
 
 echo "Turning back on fsync and hot_standby wal level"
 sed -i \


### PR DESCRIPTION
Running large anonymisation scripts writes loads of data to disk. One
thing that can significantly impact performance is the amount of WAL we
write to disk, and whether Postgres calls fsync to guarantee data
integrity after each write.

We can make finalisation much faster by disabling fsync (as we can
easily recreate a draupnir image from a backup, so we're not worried
about crash-safety here) and reducing the amount of data we write to our
WAL files.

We were previously using hot_standby WAL level, which meant we wrote all
the data required to power live read queries on a standby, which is
significantly more than the minimal/warm-standby level. We can change to
minimal for the anonymisation work, but should change back to
hot_standby for the live instances to ensure they better mirror
production performance.