### PR TITLE
Revoke existing tokens when re-authing

### DIFF
--- a/cmd/draupnir/draupnir.go
+++ b/cmd/draupnir/draupnir.go
@@ -118,12 +118,13 @@ func main() {
 			Name:    "authenticate",
 			Aliases: []string{},
 			Usage:   "authenticate with google",
+			Flags:   []cli.Flag{cli.BoolFlag{Name: "force", Usage: "Force reauthentication"}},
 			Action: func(c *cli.Context) error {
 				cfg := loadConfig(logger)
 				client := NewClient(c, logger)
 
-				if cfg.Token.RefreshToken != "" {
-					logger.Info("You're already authenticated")
+				if cfg.Token.RefreshToken != "" && !c.Bool("force") {
+					logger.Info("You're already authenticated. Pass --force to reauthenticate.")
 					return nil
 				}
 

--- a/pkg/server/api/routes/access_tokens_test.go
+++ b/pkg/server/api/routes/access_tokens_test.go
@@ -61,7 +61,7 @@ func TestCallback(t *testing.T) {
 	oauthClient := auth.FakeOAuthClient{
 		MockExchange: func(ctx context.Context, _code string) (*oauth2.Token, error) {
 			assert.Equal(t, code, _code)
-			return &oauth2.Token{AccessToken: "the-access-token"}, nil
+			return &oauth2.Token{RefreshToken: "the-access-token"}, nil
 		},
 	}
 
@@ -87,7 +87,7 @@ func TestCallback(t *testing.T) {
 
 	select {
 	case result := <-callback:
-		assert.Equal(t, OAuthCallback{Token: oauth2.Token{AccessToken: "the-access-token"}, Error: nil}, result)
+		assert.Equal(t, OAuthCallback{Token: oauth2.Token{RefreshToken: "the-access-token"}, Error: nil}, result)
 	default:
 		t.Fatal("Received nothing in channel")
 	}


### PR DESCRIPTION
This will improve the UX for users who somehow lose their existing token
(e.g. they get a new laptop). We take the approach suggested by Google [here](https://developers.google.com/identity/protocols/OAuth2WebServer#tokenrevoke).