### PR TITLE
Add Vagrant VM for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /draupnir-client
 *.*_amd64
 *.deb
+*.log
 /.bundle
 /.kitchen
 /.env

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,17 @@ BUILD_COMMAND=go build -ldflags "-X github.com/gocardless/draupnir/pkg/version.V
 
 .PHONY: build client clean test test-integration dump-schema publish-circleci-dockerfile
 
-build:
-	$(BUILD_COMMAND) -o draupnir cmd/draupnir/draupnir.go
+build-linux:
+	GOOS=linux GOARCH=amd64 $(BUILD_COMMAND) -o draupnir.linux_amd64 cmd/draupnir/draupnir.go
+
+build-osx:
+	GOOS=darwin GOARCH=amd64 $(BUILD_COMMAND) -o draupnir.darwin_amd64 cmd/draupnir/draupnir.go
+
+build: build-linux build-osx
 
 migrate:
-	vendor/bin/sql-migrate up
+	# https://github.com/rubenv/sql-migrate
+	sql-migrate up
 
 dump-schema:
 	pg_dump -sxOf structure.sql draupnir

--- a/README.md
+++ b/README.md
@@ -30,6 +30,37 @@ Migrate the database
 make migrate
 ```
 
+Development (Vagrant VM)
+------------------------
+
+It will often be desirable to run a full virtual machine, with btrfs, in order
+to test the complete Draupnir flow. This can be achieved via the included
+Vagrant configuration.
+
+Install prerequisites:
+```
+brew cask install virtualbox vagrant
+```
+
+Build the Linux binary
+```
+make build-linux
+```
+
+Boot Vagrant VM:
+```
+vagrant up
+```
+
+Login and use Draupnir
+```
+vagrant ssh
+$ sudo su -
+# eval $(/draupnir/draupnir.linux_amd64 --insecure new)
+# export PGHOST=localhost
+# psql
+```
+
 Tests
 -----
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# frozen_string_literal: true
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.network "forwarded_port", guest: 8443, host: 9443, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 8080, host: 9080, host_ip: "127.0.0.1"
+
+  config.vm.synced_folder ".", "/draupnir"
+
+  # create disk
+  data_disk_image = "./tmp/data_disk.vdi"
+  config.vm.provider "virtualbox" do |v|
+    unless File.exist?(data_disk_image)
+      v.customize ["createhd", "--filename", data_disk_image, "--size", 1024]
+    end
+    v.customize [
+      "storageattach", :id,
+      "--storagectl", "SCSI",
+      "--port", 2,
+      "--device", 0,
+      "--type", "hdd",
+      "--medium", data_disk_image
+    ]
+  end
+
+  config.vm.provision "shell", path: "vagrant/provision.sh"
+end

--- a/dbconfig.yml
+++ b/dbconfig.yml
@@ -1,4 +1,10 @@
+---
 development:
   dialect: postgres
   datasource: dbname=draupnir sslmode=disable
+  dir: migrations
+
+vagrant:
+  dialect: postgres
+  datasource: host=/run/postgresql dbname=draupnir sslmode=disable
   dir: migrations

--- a/vagrant/anonymisation.sql
+++ b/vagrant/anonymisation.sql
@@ -1,0 +1,2 @@
+-- Do not perform any anonymisation steps
+SELECT NOW();

--- a/vagrant/draupnir.service
+++ b/vagrant/draupnir.service
@@ -1,0 +1,9 @@
+[Unit]
+Description = Draupnir
+After = network.target
+
+[Service]
+User = draupnir
+ExecStart = /draupnir/draupnir.linux_amd64 server
+Restart = always
+KillMode = process

--- a/vagrant/draupnir_client_config.toml
+++ b/vagrant/draupnir_client_config.toml
@@ -1,0 +1,3 @@
+Domain = "localhost:8443"
+[Token]
+  RefreshToken = "the_shared_secret"

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -1,0 +1,16 @@
+database_url = "host=/run/postgresql user=draupnir dbname=draupnir"
+data_path = "/data"
+environment = "development"
+shared_secret = "the_shared_secret"
+trusted_user_email_domain = "@gocardless.com"
+
+[http]
+port = 8443
+insecure_port = 8080
+tls_certificate = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+tls_private_key = "/etc/ssl/private/ssl-cert-snakeoil.key"
+
+[oauth]
+redirect_url = "https://example.com/oauth_callback"
+client_id = "client_id"
+client_secret = "client_secret"

--- a/vagrant/example_db.sql
+++ b/vagrant/example_db.sql
@@ -1,0 +1,15 @@
+-- use createdb -o test test ?
+
+CREATE DATABASE test;
+
+CREATE user test WITH encrypted password '';
+GRANT ALL privileges ON DATABASE test TO test;
+
+\c test
+
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  first_name TEXT,
+  last_name TEXT,
+  email TEXT UNIQUE NOT NULL
+);

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+# prevent psql error messages
+cd /
+
+# add postgres repo
+cat > /etc/apt/sources.list.d/pgdg.list <<END
+deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+END
+
+# get the signing key and import it
+curl -Ss https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# fetch the metadata from the new repo
+apt-get update
+
+# install postgres 11 and go. build-essential is required for cgo
+apt-get install -y --no-install-recommends build-essential postgresql-11 golang-go
+export PATH=$PATH:/root/go/bin
+
+# install sql-migrate
+go get -v github.com/rubenv/sql-migrate/...
+cp /root/go/bin/sql-migrate /usr/local/bin
+
+mkdir -p /data
+
+# create and mount btrfs
+if ! btrfs filesystem df /data >/dev/null 2>&1; then
+    mkfs.btrfs -f /dev/sdc
+    mount /dev/sdc /data
+fi
+
+# create system user
+getent passwd draupnir >/dev/null || useradd --groups ssl-cert --create-home draupnir
+
+# create draupnir directories
+mkdir -p /data/{image_uploads,image_snapshots,instances}
+chown -R draupnir /data
+
+# Ubuntu starts the DB after installation. Stop so that we can make a copy of the DB.
+pg_ctlcluster 11 main stop
+# wait for postgres to stop, so that the pid file disappears
+sleep 1
+
+if [ ! -d /data/example_db ]; then
+  mkdir /data/example_db
+  chown postgres:postgres /data/example_db
+  sudo -u postgres /usr/lib/postgresql/11/bin/initdb /data/example_db
+
+  sudo -u postgres /usr/lib/postgresql/11/bin/pg_ctl -D /data/example_db -o '-c data_directory=/data/example_db' start
+  sudo -u postgres psql -f /draupnir/vagrant/example_db.sql
+  sudo -u postgres /usr/lib/postgresql/11/bin/pg_ctl -D /data/example_db -o '-c data_directory=/data/example_db' stop
+fi
+
+# start draupnir postgres
+pg_ctlcluster 11 main start
+
+# create draupnir user
+if ! sudo -u postgres psql -Atc "SELECT 1 FROM pg_roles WHERE rolname='draupnir'" | grep -q 1; then
+  sudo -u postgres createuser draupnir
+fi
+# create draupnir database
+if ! sudo -u postgres psql -Atc "SELECT 1 FROM pg_database WHERE datname='draupnir'" | grep -q 1; then
+  sudo -u postgres createdb --owner=draupnir draupnir
+fi
+
+cd /draupnir && sudo -u draupnir sql-migrate up -env=vagrant && cd -
+
+# prepare configuration
+mkdir -p /etc/draupnir
+ln -sf /draupnir/vagrant/draupnir_config.toml /etc/draupnir/config.toml
+ln -sf /draupnir/vagrant/draupnir_client_config.toml /root/.draupnir
+ln -sf /draupnir/vagrant/draupnir.service /etc/systemd/system/draupnir.service
+
+# make scripts availabe on PATH
+ln -sf /draupnir/cmd/draupnir-* /usr/local/bin
+# allow Draupnir to sudo its scripts
+cp -f /draupnir/vagrant/sudoers_draupnir /etc/sudoers.d/draupnir
+
+systemctl start draupnir
+
+# wait for the server to boot up, before trying to create an image
+sleep 1
+
+# create an image, if one doesn't already exist
+if ! /draupnir/draupnir.linux_amd64 --insecure images list | grep -E 'READY:.*true'; then
+    # create draupnir image
+    IMAGE_ID=$(/draupnir/draupnir.linux_amd64 --insecure images create "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "/draupnir/vagrant/anonymisation.sql" | awk '{print $1}')
+    IMAGE_PATH="/data/image_uploads/${IMAGE_ID}"
+
+    cp -rp /data/example_db/* "${IMAGE_PATH}"
+
+    cat > "${IMAGE_PATH}/pg_hba.conf" <<-EOF
+    local   all     all                     trust
+    host    all     all     0.0.0.0/0       trust
+EOF
+
+    chown -R postgres:postgres "${IMAGE_PATH}"
+    /draupnir/draupnir.linux_amd64 --insecure images finalise "${IMAGE_ID}"
+fi

--- a/vagrant/sudoers_draupnir
+++ b/vagrant/sudoers_draupnir
@@ -1,0 +1,4 @@
+draupnir ALL=(root) NOPASSWD:/usr/local/bin/draupnir-finalise-image *
+draupnir ALL=(root) NOPASSWD:/usr/local/bin/draupnir-create-instance *
+draupnir ALL=(root) NOPASSWD:/usr/local/bin/draupnir-destroy-image *
+draupnir ALL=(root) NOPASSWD:/usr/local/bin/draupnir-destroy-instance *


### PR DESCRIPTION
Developing draupnir is hard without a full environment set up. Using
Vagrant we can provide btrfs and a PostgreSQL server so that a locally
developed version of draupnir can run in a fully functional environment.