### PR TITLE
Clean up old instances

### DIFF
--- a/migrations/2019-06-19_16-47_add_refresh_token_to_instances.sql
+++ b/migrations/2019-06-19_16-47_add_refresh_token_to_instances.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE instances ADD COLUMN refresh_token text;
+
+-- +migrate Down
+ALTER TABLE instances DROP COLUMN refresh_token;

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -33,7 +33,7 @@ func GetLogger(ctx context.Context) log.Logger {
 	if !ok {
 		// Only a programming bug should cause this scenario, so exit the program
 		// if it occurs.
-		log.Fatal("Unable to retrieve logger from context, log lines will be missing")
+		log.Fatal("Unable to retrieve logger from context")
 	}
 	return *logger
 }

--- a/pkg/models/instance.go
+++ b/pkg/models/instance.go
@@ -5,23 +5,25 @@ import (
 )
 
 type Instance struct {
-	ID        int    `jsonapi:"primary,instances"`
-	Hostname  string `jsonapi:"attr,hostname"`
-	ImageID   int    `jsonapi:"attr,image_id"`
-	UserEmail string
-	CreatedAt time.Time `jsonapi:"attr,created_at,iso8601"`
-	UpdatedAt time.Time `jsonapi:"attr,updated_at,iso8601"`
-	Port      int       `jsonapi:"attr,port"`
+	ID           int    `jsonapi:"primary,instances"`
+	Hostname     string `jsonapi:"attr,hostname"`
+	ImageID      int    `jsonapi:"attr,image_id"`
+	UserEmail    string
+	RefreshToken string
+	CreatedAt    time.Time `jsonapi:"attr,created_at,iso8601"`
+	UpdatedAt    time.Time `jsonapi:"attr,updated_at,iso8601"`
+	Port         int       `jsonapi:"attr,port"`
 
 	Credentials *InstanceCredentials `jsonapi:"relation,credentials"`
 }
 
-func NewInstance(imageID int, email string) Instance {
+func NewInstance(imageID int, email, refreshToken string) Instance {
 	return Instance{
-		ImageID:   imageID,
-		UserEmail: email,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ImageID:      imageID,
+		UserEmail:    email,
+		RefreshToken: refreshToken,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
 	}
 }
 

--- a/pkg/server/api/auth/auth.go
+++ b/pkg/server/api/auth/auth.go
@@ -20,7 +20,8 @@ type Authenticator interface {
 	// user, or an error.
 	// TODO: maybe this should be Authenticate(string) (string, error)
 	// Taking the Authorization header and returning the email address
-	AuthenticateRequest(*http.Request) (string, error)
+	AuthenticateRequest(*http.Request) (string, string, error)
+	IsRefreshTokenValid(string) (bool, error, error)
 }
 
 type GoogleAuthenticator struct {
@@ -29,28 +30,49 @@ type GoogleAuthenticator struct {
 	TrustedUserEmailDomain string
 }
 
-func (g GoogleAuthenticator) AuthenticateRequest(r *http.Request) (string, error) {
-	var accessToken string
-	_, err := fmt.Sscanf(r.Header.Get("Authorization"), "Bearer %s", &accessToken)
+func (g GoogleAuthenticator) AuthenticateRequest(r *http.Request) (string, string, error) {
+	var refreshToken string
+	_, err := fmt.Sscanf(r.Header.Get("Authorization"), "Bearer %s", &refreshToken)
 	if err != nil {
-		return "", fmt.Errorf("Error extracting token from Authorization header: %s", err.Error())
+		return "", "", fmt.Errorf("Error extracting token from Authorization header: %s", err.Error())
 	}
 
 	// abr uses a shared secret to authenticate
-	if accessToken == g.SharedSecret {
-		return UPLOAD_USER_EMAIL, nil
+	if refreshToken == g.SharedSecret {
+		return UPLOAD_USER_EMAIL, "", nil
 	}
 
-	email, err := g.OAuthClient.LookupAccessToken(accessToken)
+	email, err := g.OAuthClient.LookupAccessToken(refreshToken)
 	if err != nil {
-		return "", fmt.Errorf("Error looking up access token: %s", err.Error())
+		return "", "", fmt.Errorf("Error looking up access token: %s", err.Error())
 	}
 
 	if !strings.HasSuffix(email, g.TrustedUserEmailDomain) {
-		return "", errors.New("Email not valid")
+		return "", "", errors.New("Email not valid")
 	}
 
-	return email, nil
+	return email, refreshToken, nil
+}
+
+// IsRefreshTokenValid checks if a refresh token is valid by requesting a new
+// access token with it.
+// The first return parameter will return true only if the token is currently
+// valid, i.e. the user has not been suspended or revoked their token.
+// The second return parameter is an error that is populated only if there has
+// been an error when attempting to determine if the token is valid.
+// The third return parameter is an error that is populated only if the token
+// is not currently valid, so can be used to determine the reason for its invalidity.
+func (g GoogleAuthenticator) IsRefreshTokenValid(refreshToken string) (bool, error, error) {
+	_, err := g.OAuthClient.LookupAccessToken(refreshToken)
+	if err != nil {
+		// invalid_grant is the error code returned when a user is deleted,
+		// suspended, or the application access has been revoked
+		if strings.Contains(err.Error(), "invalid_grant") {
+			return false, nil, err
+		}
+		return false, err, nil
+	}
+	return true, nil, nil
 }
 
 type OAuthClient interface {
@@ -87,8 +109,8 @@ func (g GoogleOAuthClient) LookupAccessToken(refreshToken string) (string, error
 // IntegrationTestOAuthClient is used for integration tests
 type IntegrationTestOAuthClient struct{}
 
-func (f IntegrationTestOAuthClient) LookupAccessToken(accessToken string) (string, error) {
-	if accessToken == "the-integration-access-token" {
+func (f IntegrationTestOAuthClient) LookupAccessToken(refreshToken string) (string, error) {
+	if refreshToken == "the-integration-access-token" {
 		return "integration-test@gocardless.com", nil
 	}
 	return "", errors.New("Invalid access token")

--- a/pkg/server/api/auth/fake.go
+++ b/pkg/server/api/auth/fake.go
@@ -8,11 +8,16 @@ import (
 )
 
 type FakeAuthenticator struct {
-	MockAuthenticateRequest func(r *http.Request) (string, error)
+	MockAuthenticateRequest func(r *http.Request) (string, string, error)
+	MockIsRefreshTokenValid func(string) (bool, error, error)
 }
 
-func (f FakeAuthenticator) AuthenticateRequest(r *http.Request) (string, error) {
+func (f FakeAuthenticator) AuthenticateRequest(r *http.Request) (string, string, error) {
 	return f.MockAuthenticateRequest(r)
+}
+
+func (f FakeAuthenticator) IsRefreshTokenValid(refreshToken string) (bool, error, error) {
+	return f.MockIsRefreshTokenValid(refreshToken)
 }
 
 type FakeOAuthClient struct {

--- a/pkg/server/api/middleware/authenticate.go
+++ b/pkg/server/api/middleware/authenticate.go
@@ -13,6 +13,7 @@ import (
 // This, sadly is exported so we can inject fake loggers in tests.
 // See routes.createRequest in server/api/routes/fakes.go
 const AuthUserKey key = 2
+const RefreshTokenKey key = 3
 
 // Authenticate uses the provided authenticator to authenticate the request.
 // On success, it yields to the next handler in the chain.
@@ -25,7 +26,7 @@ func Authenticate(authenticator auth.Authenticator) chain.Middleware {
 				return err
 			}
 
-			email, err := authenticator.AuthenticateRequest(r)
+			email, refreshToken, err := authenticator.AuthenticateRequest(r)
 			if err != nil {
 				logger.Info(err.Error())
 				api.UnauthorizedError.Render(w, http.StatusUnauthorized)
@@ -33,6 +34,7 @@ func Authenticate(authenticator auth.Authenticator) chain.Middleware {
 			}
 
 			r = r.WithContext(context.WithValue(r.Context(), AuthUserKey, email))
+			r = r.WithContext(context.WithValue(r.Context(), RefreshTokenKey, refreshToken))
 			return next(w, r)
 		}
 	}

--- a/pkg/server/api/middleware/authenticate_test.go
+++ b/pkg/server/api/middleware/authenticate_test.go
@@ -15,8 +15,8 @@ import (
 
 type FailureAuthenticator struct{}
 
-func (f FailureAuthenticator) AuthenticateRequest(r *http.Request) (string, error) {
-	return "", errors.New("could not authenticate")
+func (f FailureAuthenticator) AuthenticateRequest(r *http.Request) (string, string, error) {
+	return "", "", errors.New("could not authenticate")
 }
 
 func TestAuthenticateSuccess(t *testing.T) {
@@ -24,8 +24,8 @@ func TestAuthenticateSuccess(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
 	authenticator := auth.FakeAuthenticator{
-		MockAuthenticateRequest: func(r *http.Request) (string, error) {
-			return "some_user@domain.org", nil
+		MockAuthenticateRequest: func(r *http.Request) (string, string, error) {
+			return "some_user@domain.org", "access_token", nil
 		},
 	}
 
@@ -45,8 +45,8 @@ func TestAuthenticateFailure(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	authenticator := auth.FakeAuthenticator{
-		MockAuthenticateRequest: func(r *http.Request) (string, error) {
-			return "", errors.New("could not authenticate")
+		MockAuthenticateRequest: func(r *http.Request) (string, string, error) {
+			return "", "", errors.New("could not authenticate")
 		},
 	}
 

--- a/pkg/server/api/routes/fakes.go
+++ b/pkg/server/api/routes/fakes.go
@@ -127,5 +127,7 @@ func createRequest(t *testing.T, method string, path string, body io.Reader) (*h
 	logger, output := NewFakeLogger()
 	req = req.WithContext(context.WithValue(req.Context(), middleware.LoggerKey, &logger))
 	req = req.WithContext(context.WithValue(req.Context(), middleware.AuthUserKey, "test@draupnir"))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.RefreshTokenKey, "refresh-token"))
+
 	return req, recorder, output
 }

--- a/pkg/server/api/routes/images_test.go
+++ b/pkg/server/api/routes/images_test.go
@@ -334,8 +334,8 @@ func TestImageDestroyFromUploadUser(t *testing.T) {
 	}
 
 	authenticator := auth.FakeAuthenticator{
-		MockAuthenticateRequest: func(r *http.Request) (string, error) {
-			return auth.UPLOAD_USER_EMAIL, nil
+		MockAuthenticateRequest: func(r *http.Request) (string, string, error) {
+			return auth.UPLOAD_USER_EMAIL, "", nil
 		},
 	}
 

--- a/pkg/server/api/routes/instances_test.go
+++ b/pkg/server/api/routes/instances_test.go
@@ -382,8 +382,8 @@ func TestInstanceDestroyFromUploadUser(t *testing.T) {
 	}
 
 	authenticator := auth.FakeAuthenticator{
-		MockAuthenticateRequest: func(r *http.Request) (string, error) {
-			return auth.UPLOAD_USER_EMAIL, nil
+		MockAuthenticateRequest: func(r *http.Request) (string, string, error) {
+			return auth.UPLOAD_USER_EMAIL, "", nil
 		},
 	}
 

--- a/pkg/server/cleaner.go
+++ b/pkg/server/cleaner.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/gocardless/draupnir/pkg/exec"
+	"github.com/gocardless/draupnir/pkg/models"
+	"github.com/gocardless/draupnir/pkg/server/api/auth"
+	"github.com/gocardless/draupnir/pkg/server/api/middleware"
+	"github.com/gocardless/draupnir/pkg/store"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/log"
+)
+
+type InstanceCleaner struct {
+	logger        log.Logger
+	sentryClient  *raven.Client
+	instanceStore store.InstanceStore
+	executor      exec.Executor
+	authenticator auth.Authenticator
+}
+
+func NewInstanceCleaner(logger log.Logger, sentryClient *raven.Client, instanceStore store.InstanceStore, executor exec.Executor, authenticator auth.Authenticator) *InstanceCleaner {
+	return &InstanceCleaner{
+		logger:        logger,
+		sentryClient:  sentryClient,
+		instanceStore: instanceStore,
+		executor:      executor,
+		authenticator: authenticator,
+	}
+}
+
+func (ic *InstanceCleaner) Start(ctx context.Context, interval time.Duration) error {
+	// We need to add a logger to the context, as the exec package depends on one
+	// being present in order to log
+	ctx = context.WithValue(ctx, middleware.LoggerKey, &ic.logger)
+	for {
+		select {
+		case <-time.After(interval):
+			ic.logger.Info("Cleaning old instances with invalid tokens")
+			instances, err := ic.instanceStore.List()
+			if err != nil {
+				err = errors.Wrap(err, "cannot clean instances: unable to list instances")
+				ic.logger.Error(err.Error())
+				ic.sentryClient.CaptureError(err, map[string]string{})
+			} else {
+				for _, instance := range instances {
+					if instance.RefreshToken != "" {
+						valid, err, validityErr := ic.authenticator.IsRefreshTokenValid(instance.RefreshToken)
+						if err != nil {
+							err = errors.Wrap(err, "failed to validate token")
+							ic.logger.With("instance", instance.ID).Error(err.Error())
+							ic.sentryClient.CaptureError(err, map[string]string{})
+						} else if !valid {
+							logger := ic.logger.With("instance", instance.ID).With("user", instance.UserEmail)
+							logger.Infof("Token for instance invalid: destroying instance: %s", validityErr.Error())
+							err = ic.destroyInstance(ctx, instance)
+							if err != nil {
+								err = errors.Wrap(err, "failed to destroy instance")
+								logger.Error(err.Error())
+								ic.sentryClient.CaptureError(err, map[string]string{})
+							}
+						}
+					}
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (ic *InstanceCleaner) destroyInstance(ctx context.Context, instance models.Instance) error {
+	err := ic.executor.DestroyInstance(ctx, instance.ID)
+	if err == nil {
+		err = ic.instanceStore.Destroy(instance)
+	}
+	return err
+}

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	SentryDsn              string      `toml:"sentry_dsn" required:"false"`
 	HTTPConfig             HTTPConfig  `toml:"http"`
 	OAuthConfig            OAuthConfig `toml:"oauth"`
+	CleanInterval          string      `toml:"clean_interval"`
 }
 
 // Load parses and validates the server config file located at `path`

--- a/pkg/store/instances.go
+++ b/pkg/store/instances.go
@@ -21,14 +21,15 @@ type DBInstanceStore struct {
 
 func (s DBInstanceStore) Create(instance models.Instance) (models.Instance, error) {
 	row := s.DB.QueryRow(
-		`INSERT INTO instances (image_id, port, created_at, updated_at, user_email)
-		 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO instances (image_id, port, created_at, updated_at, user_email, refresh_token)
+		 VALUES ($1, $2, $3, $4, $5, $6)
 		 RETURNING id`,
 		instance.ImageID,
 		instance.Port,
 		instance.CreatedAt,
 		instance.UpdatedAt,
 		instance.UserEmail,
+		instance.RefreshToken,
 	)
 
 	err := row.Scan(&instance.ID)
@@ -41,7 +42,7 @@ func (s DBInstanceStore) List() ([]models.Instance, error) {
 	instances := make([]models.Instance, 0)
 
 	rows, err := s.DB.Query(
-		`SELECT id, image_id, port, created_at, updated_at, user_email
+		`SELECT id, image_id, port, created_at, updated_at, user_email, refresh_token
 		 FROM instances
 		 ORDER BY id ASC`,
 	)
@@ -60,6 +61,7 @@ func (s DBInstanceStore) List() ([]models.Instance, error) {
 			&instance.CreatedAt,
 			&instance.UpdatedAt,
 			&instance.UserEmail,
+			&instance.RefreshToken,
 		)
 
 		if err != nil {

--- a/spec/fixtures/bootstrap
+++ b/spec/fixtures/bootstrap
@@ -33,9 +33,9 @@ cp /workspace/spec/fixtures/config.toml /etc/draupnir/config.toml
 # Boot draupnir
 /workspace/draupnir.linux_amd64 server >/var/log/draupnir.log 2>&1 &
 timeout 5 bash <<POLL 1>&2
-until curl --silent https://localhost:8443/health_check; do
+until curl --output /dev/null --silent --fail --insecure https://localhost:8443/health_check
+do
   sleep 0.2
 done
-
-echo health check successful!
+echo "Draupnir health check successful - starting tests!"
 POLL

--- a/spec/fixtures/config.toml
+++ b/spec/fixtures/config.toml
@@ -4,6 +4,7 @@ environment = "test"
 shared_secret = "thesharedsecret"
 trusted_user_email_domain = "@gocardless.com"
 public_hostname = "localhost"
+clean_interval = "30m"
 
 [http]
 port = 8443

--- a/structure.sql
+++ b/structure.sql
@@ -87,7 +87,8 @@ CREATE TABLE instances (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     port integer NOT NULL,
-    user_email text
+    user_email text,
+    refresh_token text
 );
 
 

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -4,6 +4,7 @@ environment = "development"
 shared_secret = "the_shared_secret"
 trusted_user_email_domain = "@gocardless.com"
 public_hostname = "localhost"
+clean_interval = "30m"
 
 [http]
 port = 8443


### PR DESCRIPTION
Store the users refresh token along with their instances so that we can
periodically test the refresh tokens validity and clean out old
instances. A refresh token is invalid if the user is suspended, deleted,
or they revoke the applications access.