### PR TITLE
Secure instances with client certificate auth

### DIFF
--- a/cmd/draupnir-create-instance
+++ b/cmd/draupnir-create-instance
@@ -31,6 +31,52 @@ INSTANCE_PATH="${ROOT}/instances/${INSTANCE_ID}"
 set -x
 
 btrfs subvolume snapshot "$SNAPSHOT_PATH" "$INSTANCE_PATH"
+
+# The instance directory must be readable by Draupnir, so that the certificates
+# can be read and served in the API response.
+sudo chown postgres:draupnir "$INSTANCE_PATH"
+sudo chmod g+rx "$INSTANCE_PATH"
+
+# Create a certificate authority
+openssl req -new -nodes -text \
+  -out "${INSTANCE_PATH}/ca.csr" -keyout "${INSTANCE_PATH}/ca.key" \
+  -subj "/CN=Draupnir instance ${INSTANCE_ID} certification authority"
+chmod 600 "${INSTANCE_PATH}/ca.key"
+
+openssl x509 -req -in "${INSTANCE_PATH}/ca.csr" -text -days 30 \
+  -extfile /etc/ssl/openssl.cnf -extensions v3_ca \
+  -signkey "${INSTANCE_PATH}/ca.key" -out "${INSTANCE_PATH}/ca.crt"
+chown postgres "${INSTANCE_PATH}/ca.crt"
+
+# Create a server certificate for the instance
+openssl req -new -nodes -text \
+  -out "${INSTANCE_PATH}/server.csr" -keyout "${INSTANCE_PATH}/server.key" \
+  -subj "/CN=Draupnir instance ${INSTANCE_ID} server"
+chmod 600 "${INSTANCE_PATH}/server.key"
+
+openssl x509 -req -in "${INSTANCE_PATH}/server.csr" -text -days 30 \
+  -CA "${INSTANCE_PATH}/ca.crt" -CAkey "${INSTANCE_PATH}/ca.key" -CAcreateserial \
+  -out "${INSTANCE_PATH}/server.crt"
+chown postgres "${INSTANCE_PATH}/server.key" "${INSTANCE_PATH}/server.crt"
+
+cat <<EOF >> "${INSTANCE_PATH}/postgresql.conf"
+ssl_ca_file = 'ca.crt'
+ssl_cert_file = 'server.crt'
+ssl_key_file = 'server.key'
+EOF
+
+# Create client certificate
+openssl req -new -nodes -text \
+  -out "${INSTANCE_PATH}/client.csr" -keyout "${INSTANCE_PATH}/client.key" \
+  -subj "/CN=Draupnir instance ${INSTANCE_ID} client"
+chmod 600 "${INSTANCE_PATH}/client.key"
+
+openssl x509 -req -in "${INSTANCE_PATH}/client.csr" -text -days 30 \
+  -CA "${INSTANCE_PATH}/ca.crt" -CAkey "${INSTANCE_PATH}/ca.key" -CAcreateserial \
+  -out "${INSTANCE_PATH}/client.crt"
+# Draupnir must be able to read the cert and key, to serve to the client
+chown draupnir "${INSTANCE_PATH}/client.key" "${INSTANCE_PATH}/client.crt"
+
 # TODO: where do we send logs?
 sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" start
 

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -135,8 +135,18 @@ sudo -u postgres $PG_CTL -D "$UPLOAD_PATH" -w stop
 sudo rm -f "${UPLOAD_PATH}/postmaster.pid"
 sudo rm -f "${UPLOAD_PATH}/postmaster.opts"
 
-# Install our own pg_hba.conf
-printf "local\tall\tall\t\ttrust\nhost\tall\tall\t0.0.0.0/0\ttrust\n" | sudo tee "${UPLOAD_PATH}/pg_hba.conf"
+# Install our own pg_hba.conf, and ensure that it cannot be modified
+cat > "${UPLOAD_PATH}/pg_hba.conf" <<EOF
+# NOTE: The clientcert=1 option is essential - without this the Draupnir
+# instance will be accessible to anyone with knowledge of the host and port.
+# Do not edit this unless you are absolutely certain of the consequences.
+local   all     all                     trust
+hostssl all     all     0.0.0.0/0       trust   clientcert=1
+EOF
+
+chown root:postgres "${UPLOAD_PATH}/pg_hba.conf"
+chmod 640 "${UPLOAD_PATH}/pg_hba.conf"
+chattr +i "${UPLOAD_PATH}/pg_hba.conf"
 
 btrfs subvolume snapshot "$UPLOAD_PATH" "$SNAPSHOT_PATH"
 

--- a/pkg/models/instance.go
+++ b/pkg/models/instance.go
@@ -11,6 +11,8 @@ type Instance struct {
 	CreatedAt time.Time `jsonapi:"attr,created_at,iso8601"`
 	UpdatedAt time.Time `jsonapi:"attr,updated_at,iso8601"`
 	Port      int       `jsonapi:"attr,port"`
+
+	Credentials *InstanceCredentials `jsonapi:"relation,credentials"`
 }
 
 func NewInstance(imageID int, email string) Instance {
@@ -19,5 +21,26 @@ func NewInstance(imageID int, email string) Instance {
 		UserEmail: email,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
+	}
+}
+
+type InstanceCredentials struct {
+	// The JSON:API spec says that we should have an ID field, even though we'll
+	// just be setting it to the same value as the instance ID.
+	// It would be nice to have this struct as an embedded object, rather than a relation, but that's not possible due to these issues:
+	// https://github.com/google/jsonapi/issues/74
+	// https://github.com/google/jsonapi/issues/117
+	ID                int    `jsonapi:"primary,credentials"`
+	CACertificate     string `jsonapi:"attr,ca_certificate"`
+	ClientCertificate string `jsonapi:"attr,client_certificate"`
+	ClientKey         string `jsonapi:"attr,client_key"`
+}
+
+func NewInstanceCredentials(id int, caCert string, clientCert string, clientKey string) InstanceCredentials {
+	return InstanceCredentials{
+		ID:                id,
+		CACertificate:     caCert,
+		ClientCertificate: clientCert,
+		ClientKey:         clientKey,
 	}
 }

--- a/pkg/server/api/middleware/check_api_version.go
+++ b/pkg/server/api/middleware/check_api_version.go
@@ -37,8 +37,7 @@ func CheckAPIVersion(serverVersion string) chain.Middleware {
 				}
 			}
 
-			next(w, r)
-			return nil
+			return next(w, r)
 		}
 	}
 }

--- a/pkg/server/api/middleware/logger.go
+++ b/pkg/server/api/middleware/logger.go
@@ -32,7 +32,7 @@ func NewRequestLogger(logger log.Logger) chain.Middleware {
 
 			// Call the next middleware and time it
 			start := time.Now()
-			next(recorder, r)
+			err := next(recorder, r)
 			duration := time.Since(start)
 
 			requestLine := fmt.Sprintf(
@@ -56,7 +56,7 @@ func NewRequestLogger(logger log.Logger) chain.Middleware {
 			}
 			w.WriteHeader(recorder.Code)
 			recorder.Body.WriteTo(w)
-			return nil
+			return err
 		}
 	}
 }

--- a/pkg/server/api/middleware/middleware.go
+++ b/pkg/server/api/middleware/middleware.go
@@ -10,15 +10,13 @@ import (
 func AsJSON(next chain.Handler) chain.Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("Content-Type", "application/json")
-		next(w, r)
-		return nil
+		return next(w, r)
 	}
 }
 
 func WithVersion(next chain.Handler) chain.Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("Draupnir-Version", version.Version)
-		next(w, r)
-		return nil
+		return next(w, r)
 	}
 }

--- a/pkg/server/api/routes/fakes.go
+++ b/pkg/server/api/routes/fakes.go
@@ -72,11 +72,12 @@ func (s FakeInstanceStore) Destroy(instance models.Instance) error {
 }
 
 type FakeExecutor struct {
-	_CreateBtrfsSubvolume func(ctx context.Context, id int) error
-	_FinaliseImage        func(ctx context.Context, image models.Image) error
-	_CreateInstance       func(ctx context.Context, imageID int, instanceID int, port int) error
-	_DestroyImage         func(ctx context.Context, id int) error
-	_DestroyInstance      func(ctx context.Context, id int) error
+	_CreateBtrfsSubvolume        func(ctx context.Context, id int) error
+	_FinaliseImage               func(ctx context.Context, image models.Image) error
+	_CreateInstance              func(ctx context.Context, imageID int, instanceID int, port int) error
+	_RetrieveInstanceCredentials func(ctx context.Context, id int) (map[string][]byte, error)
+	_DestroyImage                func(ctx context.Context, id int) error
+	_DestroyInstance             func(ctx context.Context, id int) error
 }
 
 func (e FakeExecutor) CreateBtrfsSubvolume(ctx context.Context, id int) error {
@@ -89,6 +90,10 @@ func (e FakeExecutor) FinaliseImage(ctx context.Context, image models.Image) err
 
 func (e FakeExecutor) CreateInstance(ctx context.Context, imageID int, instanceID int, port int) error {
 	return e._CreateInstance(ctx, imageID, instanceID, port)
+}
+
+func (e FakeExecutor) RetrieveInstanceCredentials(ctx context.Context, id int) (map[string][]byte, error) {
+	return e._RetrieveInstanceCredentials(ctx, id)
 }
 
 func (e FakeExecutor) DestroyImage(ctx context.Context, id int) error {

--- a/pkg/server/api/routes/fixtures.go
+++ b/pkg/server/api/routes/fixtures.go
@@ -66,7 +66,9 @@ var createInstanceFixture = jsonapi.OnePayload{
 			"updated_at": "2016-01-01T12:33:44Z",
 			"port":       float64(0),
 		},
+		Relationships: relationshipsFixture,
 	},
+	Included: []*jsonapi.Node{credentialsFixture},
 }
 
 var listInstancesFixture = jsonapi.ManyPayload{
@@ -93,6 +95,27 @@ var getInstanceFixture = jsonapi.OnePayload{
 			"created_at": "2016-01-01T12:33:44Z",
 			"port":       float64(5432),
 			"updated_at": "2016-01-01T12:33:44Z",
+		},
+		Relationships: relationshipsFixture,
+	},
+	Included: []*jsonapi.Node{credentialsFixture},
+}
+
+var credentialsFixture = &jsonapi.Node{
+	Type: "credentials",
+	ID:   "1",
+	Attributes: map[string]interface{}{
+		"ca_certificate":     "-----BEGIN CERTIFICATE-----CA...",
+		"client_certificate": "-----BEGIN CERTIFICATE-----client...",
+		"client_key":         "-----BEGIN PRIVATE KEY-----client...",
+	},
+}
+
+var relationshipsFixture = map[string]interface{}{
+	"credentials": map[string]interface{}{
+		"data": map[string]interface{}{
+			"id":   "1",
+			"type": "credentials",
 		},
 	},
 }


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/PT-3043

When creating a new instance, generate a unique CA, server and client
certificate.

When the Draupnir client sets the environment up, retrieve the client
cert, key and CA from the instance directory and provision these on the
local machine, allowing for secure authentication with the instance.

---

I've also added some bugfixes into this PR, that I had to make in order to succesfully debug test failures, so it's probably worth viewing this commit-by-commit. I can pull these out into a separate PR if the reviewer prefers, but at the moment I feel like it makes sense to test as one chunk of work.

---

To test, perform the following steps:

```console
# on host machine:
make build-linux

# in VM (vagrant up && vagrant ssh):
systemctl restart draupnir

## Setup a new instance and connect to it
eval $(/draupnir/draupnir.linux_amd64 --insecure new); export PGHOST=localhost
psql

## Check that the env command returns the correct credentials
/draupnir/draupnir.linux_amd64 --insecure env 2

## Optionally, have a look at the API response
curl -Ss -v -H 'Authorization: Bearer the_shared_secret' -H 'Draupnir-Version: 3.1.0' -k https://localhost:8443/instances/2
```