### PR TITLE
Allow configuration of an instance hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Draupnir to boot. The variables are as follows:
 | `environment`              | True     | The environment. This can be any value, but if it is set to "test", draupnir will use a stubbed authentication client which allows all requests specifying an access token of `the-integration-access-token`. This is intended for integration tests - don't use it in production. The environment will be included in all log messages.
 | `shared_secret`            | True     | A hardcoded access token that can be used by automated scripts which can't authenticate via OAuth. At GoCardless we use this to automatically create new images.
 | `trusted_user_email_domain`| True     | The domain under which users are considered "trusted". This is draupnir's rudimentary form of authentication: if a user athenticates via OAuth and their email address is under this domain, they will be allowed to use the service. This domain must start with a `@`, e.g. `@gocardless.com`.
+| `public_hostname`          | True     | The hostname that will be set as PGHOST. This is configurable as it may be different to the hostname of the _API address_ that clients communicate with.
 | `sentry_dsn`               | False    | The DSN for your [Sentry](https://sentry.io/) project, if you're using Sentry.
 | `http.port`                | True     | The port that the HTTPS server will bind to.
 | `http.insecure_port`       | True     | The port that the HTTP server will bind to.

--- a/cmd/draupnir/draupnir.go
+++ b/cmd/draupnir/draupnir.go
@@ -436,7 +436,7 @@ func setupClientEnvironment(config config.Config, instance models.Instance) erro
 	// https://www.postgresql.org/docs/current/libpq-envars.html
 	fmt.Printf(
 		"export PGHOST=%s PGPORT=%d PGUSER=postgres PGPASSWORD='' PGDATABASE=%s PGSSLMODE=verify-ca PGSSLROOTCERT='%s' PGSSLCERT='%s' PGSSLKEY='%s'\n",
-		config.Domain,
+		instance.Hostname,
 		instance.Port,
 		database,
 		caCertPath,

--- a/pkg/models/instance.go
+++ b/pkg/models/instance.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Instance struct {
-	ID        int `jsonapi:"primary,instances"`
-	ImageID   int `jsonapi:"attr,image_id"`
+	ID        int    `jsonapi:"primary,instances"`
+	Hostname  string `jsonapi:"attr,hostname"`
+	ImageID   int    `jsonapi:"attr,image_id"`
 	UserEmail string
 	CreatedAt time.Time `jsonapi:"attr,created_at,iso8601"`
 	UpdatedAt time.Time `jsonapi:"attr,updated_at,iso8601"`

--- a/pkg/server/api/routes/fixtures.go
+++ b/pkg/server/api/routes/fixtures.go
@@ -62,6 +62,7 @@ var createInstanceFixture = jsonapi.OnePayload{
 		ID:   "1",
 		Attributes: map[string]interface{}{
 			"image_id":   float64(1),
+			"hostname":   "draupnir-server.example.com",
 			"created_at": "2016-01-01T12:33:44Z",
 			"updated_at": "2016-01-01T12:33:44Z",
 			"port":       float64(0),
@@ -78,6 +79,7 @@ var listInstancesFixture = jsonapi.ManyPayload{
 			ID:   "1",
 			Attributes: map[string]interface{}{
 				"image_id":   float64(1),
+				"hostname":   "draupnir-server.example.com",
 				"created_at": "2016-01-01T12:33:44Z",
 				"port":       float64(5432),
 				"updated_at": "2016-01-01T12:33:44Z",
@@ -92,6 +94,7 @@ var getInstanceFixture = jsonapi.OnePayload{
 		ID:   "1",
 		Attributes: map[string]interface{}{
 			"image_id":   float64(1),
+			"hostname":   "draupnir-server.example.com",
 			"created_at": "2016-01-01T12:33:44Z",
 			"port":       float64(5432),
 			"updated_at": "2016-01-01T12:33:44Z",

--- a/pkg/server/api/routes/instances_test.go
+++ b/pkg/server/api/routes/instances_test.go
@@ -36,6 +36,7 @@ func TestInstanceCreate(t *testing.T) {
 			assert.True(t, instance.Port < 6000, "port is less than 6000")
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				CreatedAt: timestamp(),
 				UpdatedAt: timestamp(),
@@ -87,6 +88,7 @@ func TestInstanceCreateReturnsErrorWithUnreadyImage(t *testing.T) {
 		_Create: func(image models.Instance) (models.Instance, error) {
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				CreatedAt: timestamp(),
 				UpdatedAt: timestamp(),
@@ -166,6 +168,7 @@ func TestInstanceList(t *testing.T) {
 			return []models.Instance{
 				models.Instance{
 					ID:        1,
+					Hostname:  "draupnir-server.example.com",
 					ImageID:   1,
 					Port:      5432,
 					CreatedAt: timestamp(),
@@ -174,6 +177,7 @@ func TestInstanceList(t *testing.T) {
 				},
 				models.Instance{
 					ID:        2,
+					Hostname:  "draupnir-server.example.com",
 					ImageID:   1,
 					Port:      5433,
 					CreatedAt: timestamp(),
@@ -202,6 +206,7 @@ func TestInstanceGet(t *testing.T) {
 		_Get: func(id int) (models.Instance, error) {
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				Port:      5432,
 				CreatedAt: timestamp(),
@@ -244,6 +249,7 @@ func TestInstanceGetFromWrongUser(t *testing.T) {
 
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				Port:      5432,
 				CreatedAt: timestamp(),
@@ -277,6 +283,7 @@ func TestInstanceDestroy(t *testing.T) {
 		_Get: func(id int) (models.Instance, error) {
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				Port:      5432,
 				CreatedAt: timestamp(),
@@ -314,6 +321,7 @@ func TestInstanceDestroyFromWrongUser(t *testing.T) {
 		_Get: func(id int) (models.Instance, error) {
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				Port:      5432,
 				CreatedAt: timestamp(),
@@ -354,6 +362,7 @@ func TestInstanceDestroyFromUploadUser(t *testing.T) {
 		_Get: func(id int) (models.Instance, error) {
 			return models.Instance{
 				ID:        1,
+				Hostname:  "draupnir-server.example.com",
 				ImageID:   1,
 				Port:      5432,
 				CreatedAt: timestamp(),

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Environment            string      `toml:"environment"`
 	SharedSecret           string      `toml:"shared_secret"`
 	TrustedUserEmailDomain string      `toml:"trusted_user_email_domain"`
+	PublicHostname         string      `toml:"public_hostname"`
 	SentryDsn              string      `toml:"sentry_dsn" required:"false"`
 	HTTPConfig             HTTPConfig  `toml:"http"`
 	OAuthConfig            OAuthConfig `toml:"oauth"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,7 +46,7 @@ func Run(logger log.Logger) error {
 		return errors.Wrap(err, "Could not connect to database")
 	}
 	imageStore := createImageStore(db)
-	instanceStore := createInstanceStore(db)
+	instanceStore := createInstanceStore(db, cfg)
 
 	imageRouteSet := routes.Images{
 		ImageStore:    imageStore,
@@ -235,8 +235,8 @@ func createImageStore(db *sql.DB) store.ImageStore {
 	return store.DBImageStore{DB: db}
 }
 
-func createInstanceStore(db *sql.DB) store.InstanceStore {
-	return store.DBInstanceStore{DB: db}
+func createInstanceStore(db *sql.DB, cfg config.Config) store.InstanceStore {
+	return store.DBInstanceStore{DB: db, PublicHostname: cfg.PublicHostname}
 }
 
 func createExecutor(c config.Config) exec.Executor {

--- a/pkg/store/instances.go
+++ b/pkg/store/instances.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+
 	"github.com/gocardless/draupnir/pkg/models"
 	_ "github.com/lib/pq" // used to setup the PG driver
 )
@@ -14,7 +15,8 @@ type InstanceStore interface {
 }
 
 type DBInstanceStore struct {
-	DB *sql.DB
+	DB             *sql.DB
+	PublicHostname string
 }
 
 func (s DBInstanceStore) Create(instance models.Instance) (models.Instance, error) {
@@ -30,6 +32,7 @@ func (s DBInstanceStore) Create(instance models.Instance) (models.Instance, erro
 	)
 
 	err := row.Scan(&instance.ID)
+	instance.Hostname = s.PublicHostname
 
 	return instance, err
 }
@@ -63,6 +66,7 @@ func (s DBInstanceStore) List() ([]models.Instance, error) {
 			return instances, err
 		}
 
+		instance.Hostname = s.PublicHostname
 		instances = append(instances, instance)
 	}
 
@@ -90,6 +94,7 @@ func (s DBInstanceStore) Get(id int) (models.Instance, error) {
 		return instance, err
 	}
 
+	instance.Hostname = s.PublicHostname
 	return instance, nil
 }
 

--- a/spec/draupnir/instance_spec.rb
+++ b/spec/draupnir/instance_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe "/instances" do
           "id" => String,
           "type" => "instances",
           "attributes" => {
+            "hostname" => "localhost",
             "image_id" => image_id.to_i,
             "port" => Numeric,
             "created_at" => String,
@@ -127,6 +128,7 @@ RSpec.describe "/instances" do
             "id" => instance_id,
             "type" => "instances",
             "attributes" => {
+              "hostname" => "localhost",
               "image_id" => image_id.to_i,
               "port" => Numeric,
               "updated_at" => String,
@@ -151,6 +153,7 @@ RSpec.describe "/instances" do
           "id" => String,
           "type" => "instances",
           "attributes" => {
+            "hostname" => "localhost",
             "image_id" => image_id.to_i,
             "port" => Numeric,
             "updated_at" => String,

--- a/spec/fixtures/config.toml
+++ b/spec/fixtures/config.toml
@@ -3,6 +3,7 @@ data_path = "/draupnir"
 environment = "test"
 shared_secret = "thesharedsecret"
 trusted_user_email_domain = "@gocardless.com"
+public_hostname = "localhost"
 
 [http]
 port = 8443

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -3,6 +3,7 @@ data_path = "/data"
 environment = "development"
 shared_secret = "the_shared_secret"
 trusted_user_email_domain = "@gocardless.com"
+public_hostname = "localhost"
 
 [http]
 port = 8443


### PR DESCRIPTION
This allows us to split the API hostname and the hostname used to
connect to Postgres instances, because we can't route Postgres traffic
through the same load balancer as the API requests.

By having the server-side set the hostname that the client should
connect to, we lay the foundations for scaling Draupnir to more than one
node too.