### PR TITLE
Allow configuration of instance port range

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Draupnir to boot. The variables are as follows:
 | `trusted_user_email_domain`| True     | The domain under which users are considered "trusted". This is draupnir's rudimentary form of authentication: if a user athenticates via OAuth and their email address is under this domain, they will be allowed to use the service. This domain must start with a `@`, e.g. `@gocardless.com`.
 | `public_hostname`          | True     | The hostname that will be set as PGHOST. This is configurable as it may be different to the hostname of the _API address_ that clients communicate with.
 | `sentry_dsn`               | False    | The DSN for your [Sentry](https://sentry.io/) project, if you're using Sentry.
+| `min_instance_port`        | True     | The minimum port number (inclusive) that may be used when creating a Draupnir instance.
+| `max_instance_port`        | True     | The maximum port number (exclusive) that may be used when creating a Draupnir instance.
 | `http.port`                | True     | The port that the HTTPS server will bind to.
 | `http.insecure_port`       | True     | The port that the HTTP server will bind to.
 | `http.tls_certificate`     | True     | The path to the TLS certificate file that the HTTPS server will use.

--- a/pkg/models/instance.go
+++ b/pkg/models/instance.go
@@ -12,7 +12,7 @@ type Instance struct {
 	RefreshToken string
 	CreatedAt    time.Time `jsonapi:"attr,created_at,iso8601"`
 	UpdatedAt    time.Time `jsonapi:"attr,updated_at,iso8601"`
-	Port         int       `jsonapi:"attr,port"`
+	Port         uint16    `jsonapi:"attr,port"`
 
 	Credentials *InstanceCredentials `jsonapi:"relation,credentials"`
 }

--- a/pkg/server/api/routes/instances.go
+++ b/pkg/server/api/routes/instances.go
@@ -74,7 +74,12 @@ func (i Instances) Create(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	instance := models.NewInstance(imageID, email, refreshToken)
-	instance.Port = generateRandomPort(i.MinInstancePort, i.MaxInstancePort)
+	port, err := generateRandomFreePort(i.InstanceStore, i.MinInstancePort, i.MaxInstancePort)
+	if err != nil {
+		return err
+	}
+	instance.Port = port
+
 	instance, err = i.InstanceStore.Create(instance)
 
 	if err != nil {
@@ -238,7 +243,33 @@ func (i Instances) Destroy(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func generateRandomPort(minPort uint16, maxPort uint16) uint16 {
-	rand.Seed(time.Now().Unix())
-	return minPort + uint16(rand.Intn(int(maxPort-minPort)))
+func generateRandomFreePort(store store.InstanceStore, minPort uint16, maxPort uint16) (uint16, error) {
+	attempts := 0
+	port := uint16(0)
+	portAvailable := false
+
+GetNewPort:
+	for !portAvailable {
+		attempts++
+		if attempts >= 100 {
+			return port, errors.Errorf("No free port found after %d attempts", attempts)
+		}
+
+		rand.Seed(time.Now().Unix() + int64(time.Now().Nanosecond()))
+		port = minPort + uint16(rand.Intn(int(maxPort-minPort)))
+
+		instances, err := store.List()
+		if err != nil {
+			return port, errors.Wrap(err, "failed to list instances to determine free port")
+		}
+
+		for _, instance := range instances {
+			if instance.Port == port {
+				goto GetNewPort
+			}
+		}
+		portAvailable = true
+	}
+
+	return port, nil
 }

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	TrustedUserEmailDomain string      `toml:"trusted_user_email_domain"`
 	PublicHostname         string      `toml:"public_hostname"`
 	SentryDsn              string      `toml:"sentry_dsn" required:"false"`
+	MinInstancePort        uint16      `toml:"min_instance_port"`
+	MaxInstancePort        uint16      `toml:"max_instance_port"`
 	HTTPConfig             HTTPConfig  `toml:"http"`
 	OAuthConfig            OAuthConfig `toml:"oauth"`
 	CleanInterval          string      `toml:"clean_interval"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,9 +56,11 @@ func Run(logger log.Logger) error {
 	}
 
 	instanceRouteSet := routes.Instances{
-		InstanceStore: instanceStore,
-		ImageStore:    imageStore,
-		Executor:      executor,
+		InstanceStore:   instanceStore,
+		ImageStore:      imageStore,
+		Executor:        executor,
+		MinInstancePort: cfg.MinInstancePort,
+		MaxInstancePort: cfg.MaxInstancePort,
 	}
 
 	accessTokenRouteSet := routes.AccessTokens{

--- a/spec/fixtures/config.toml
+++ b/spec/fixtures/config.toml
@@ -5,6 +5,8 @@ shared_secret = "thesharedsecret"
 trusted_user_email_domain = "@gocardless.com"
 public_hostname = "localhost"
 clean_interval = "30m"
+min_instance_port = 16384
+max_instance_port = 20480
 
 [http]
 port = 8443

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -5,6 +5,8 @@ shared_secret = "the_shared_secret"
 trusted_user_email_domain = "@gocardless.com"
 public_hostname = "localhost"
 clean_interval = "30m"
+min_instance_port = 7432
+max_instance_port = 8432
 
 [http]
 port = 8443


### PR DESCRIPTION
f0fbb83: Allow configuration of instance port range

This helps when defining a firewall range to open up access to the
Postgres instances.

8886728: Decrease the potential for port collisions

Currently there is a high chance of collisions when booting a new
Draupnir instance. As per the birthday problem formula, if there are 10
instances running, with a port range of 1000 ports, then we've got a 10%
chance of colliding. When this happens the instance fails to start, and
the user is returned an unhelpful error about an internal server error.

To resolve this, two changes have been made:
1. The random number generator is seeded with nanoseconds, rather than
   just seconds, which helps us in the case of two requests that arrive
   within the same second.
2. The list of existing instances is consulted, and if the
   randomly-chosen port is already assigned to an instance then another is
   picked instead.