### PR TITLE
Update TLS cipher suite configuration

### DIFF
--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -81,6 +81,8 @@ shared_preload_libraries = 'pg_stat_statements'
 ssl = on
 ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
+ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1'
+ssl_prefer_server_ciphers = 'on'
 temp_file_limit = 5242880 # 5GiB
 work_mem = '128MB'
 


### PR DESCRIPTION
Make sure to explicitly ban SSLv2 and SSLv3 (although the system
configuration already prevented these), as well as ensuring that TLSv1.2
and above are the only supported versions.

Additionally restrict the cipher suites that are available to use; this
effectively removes the ciphers which employed SHA-1 from the list.

The resulting cipher suites, according to `sslyze --sslv2 --sslv3
--tlsv1 --tlsv1_1 --tlsv1_2 localhost:xxxx --starttls=postgres
--hide_rejected_ciphers` is:

```
Preferred:
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
Accepted:
   ARIA128-GCM-SHA256                                -              128 bits
   ARIA256-GCM-SHA384                                -              256 bits
   DHE-RSA-ARIA128-GCM-SHA256                        -              128 bits
   DHE-RSA-ARIA256-GCM-SHA384                        -              256 bits
   DHE_RSA_WITH_AES_128_CCM                          -              128 bits
   DHE_RSA_WITH_AES_128_CCM_8                        -              128 bits
   DHE_RSA_WITH_AES_256_CCM_8                        -              256 bits
   ECDHE-ARIA128-GCM-SHA256                          -              128 bits
   ECDHE-ARIA256-GCM-SHA384                          -              256 bits
   RSA_WITH_AES_128_CCM                              -              128 bits
   RSA_WITH_AES_128_CCM_8                            -              128 bits
   RSA_WITH_AES_256_CCM                              -              256 bits
   RSA_WITH_AES_256_CCM_8                            -              256 bits
   TLS_DHE_RSA_WITH_AES_128_CBC_SHA256               DH-2048 bits   128 bits
   TLS_DHE_RSA_WITH_AES_128_GCM_SHA256               DH-2048 bits   128 bits
   TLS_DHE_RSA_WITH_AES_256_CBC_SHA256               DH-2048 bits   256 bits
   TLS_DHE_RSA_WITH_AES_256_CCM                      -              256 bits
   TLS_DHE_RSA_WITH_AES_256_GCM_SHA384               DH-2048 bits   256 bits
   TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256          -              128 bits
   TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256          -              256 bits
   TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256         -              256 bits
   TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             ECDH-256 bits  128 bits
   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             ECDH-256 bits  128 bits
   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384             ECDH-256 bits  256 bits
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             ECDH-256 bits  256 bits
   TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256        -              128 bits
   TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384        -              256 bits
   TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       -              256 bits
   TLS_RSA_WITH_AES_128_CBC_SHA256                   -              128 bits
   TLS_RSA_WITH_AES_128_GCM_SHA256                   -              128 bits
   TLS_RSA_WITH_AES_256_CBC_SHA256                   -              256 bits
   TLS_RSA_WITH_AES_256_GCM_SHA384                   -              256 bits
   TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256              -              128 bits
   TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256              -              256 bits
```