### PR TITLE
Verify instance auth settings upon creation

### DIFF
--- a/cmd/draupnir-create-instance
+++ b/cmd/draupnir-create-instance
@@ -16,6 +16,15 @@ if ! [[ "$#" -eq 4 ]]; then
   exit 1
 fi
 
+die_and_stop() {
+  echo "$*" 1>&2
+
+  echo "Stopping instance"
+  sudo -u postgres "$PG_CTL" -w -D "$INSTANCE_PATH" stop
+
+  exit 1
+}
+
 PG_CTL=/usr/lib/postgresql/11/bin/pg_ctl
 
 ROOT=$1
@@ -77,7 +86,38 @@ openssl x509 -req -in "${INSTANCE_PATH}/client.csr" -text -days 30 \
 # Draupnir must be able to read the cert and key, to serve to the client
 chown draupnir "${INSTANCE_PATH}/client.key" "${INSTANCE_PATH}/client.crt"
 
-# TODO: where do we send logs?
-sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" start
+# Temporarily disable connections, until we have validated that the instance
+# has authentication correctly configured
+cat <<EOF >> "${INSTANCE_PATH}/postgresql.auto.conf"
+listen_addresses = 'localhost'
+EOF
+chmod 640 "${INSTANCE_PATH}/postgresql.auto.conf"
+
+sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" start
+
+# Verify that our instance has the correct authentication restrictions, so that
+# we can be sure it is not accessible to anyone not connecting in the expected
+# manner.
+PGSSLMODE=disable \
+  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+    && die_and_stop "ERROR: Able to connect via non-TLS connection" \
+    || echo "INFO: Not able to connect via non-TLS connection"
+
+PGSSLMODE=verify-ca \
+  PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
+  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+    && die_and_stop "ERROR: Able to connect via TLS connection without client certificate" \
+    || echo "INFO: Not able to connect without client certificate"
+
+PGSSLMODE=verify-ca \
+  PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
+  PGSSLCERT="${INSTANCE_PATH}/client.crt" \
+  PGSSLKEY="${INSTANCE_PATH}/client.key" \
+  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+    || die_and_stop "ERROR: Unable to connect via client-authenticated TLS connection"
+
+rm -v "${INSTANCE_PATH}/postgresql.auto.conf"
+
+sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" restart
 
 set +x


### PR DESCRIPTION
The security of instances currently depends on the fact that an image
has been finalised with a `hostssl ... trust clientcert=1` line in the
`pg_hba.conf`.
Without this line present, and in the correct format, it'd be possible
for anyone to connect to an instance without providing credentials.

As an additional verification step, add checks at instance-creation time
that ensure that it's not possible to connect to an instance without
TLS, or without providing a client certificate. While these checks are
being performed, the instance is listening on the local interface only,
and therefore is inaccessible to external users.

If these checks fails then the instance is shut down and the
provisioning process returns an error, which will be sent back to the
client and trigger a Sentry.