### PR TITLE
Don't run draupnir instances as the postgres user

### DIFF
--- a/cmd/draupnir-create-instance
+++ b/cmd/draupnir-create-instance
@@ -20,7 +20,7 @@ die_and_stop() {
   echo "$*" 1>&2
 
   echo "Stopping instance"
-  sudo -u postgres "$PG_CTL" -w -D "$INSTANCE_PATH" stop
+  sudo -u draupnir-instance "$PG_CTL" -w -D "$INSTANCE_PATH" stop
 
   exit 1
 }
@@ -43,7 +43,7 @@ btrfs subvolume snapshot "$SNAPSHOT_PATH" "$INSTANCE_PATH"
 
 # The instance directory must be readable by Draupnir, so that the certificates
 # can be read and served in the API response.
-sudo chown postgres:draupnir "$INSTANCE_PATH"
+sudo chown draupnir-instance:draupnir "$INSTANCE_PATH"
 sudo chmod g+rx "$INSTANCE_PATH"
 
 # Create a certificate authority
@@ -55,7 +55,7 @@ chmod 600 "${INSTANCE_PATH}/ca.key"
 openssl x509 -req -in "${INSTANCE_PATH}/ca.csr" -text -days 30 \
   -extfile /etc/ssl/openssl.cnf -extensions v3_ca \
   -signkey "${INSTANCE_PATH}/ca.key" -out "${INSTANCE_PATH}/ca.crt"
-chown postgres "${INSTANCE_PATH}/ca.crt"
+chown draupnir-instance "${INSTANCE_PATH}/ca.crt"
 
 # Create a server certificate for the instance
 openssl req -new -nodes -text \
@@ -66,7 +66,7 @@ chmod 600 "${INSTANCE_PATH}/server.key"
 openssl x509 -req -in "${INSTANCE_PATH}/server.csr" -text -days 30 \
   -CA "${INSTANCE_PATH}/ca.crt" -CAkey "${INSTANCE_PATH}/ca.key" -CAcreateserial \
   -out "${INSTANCE_PATH}/server.crt"
-chown postgres "${INSTANCE_PATH}/server.key" "${INSTANCE_PATH}/server.crt"
+chown draupnir-instance "${INSTANCE_PATH}/server.key" "${INSTANCE_PATH}/server.crt"
 
 cat <<EOF >> "${INSTANCE_PATH}/postgresql.conf"
 ssl_ca_file = 'ca.crt'
@@ -86,6 +86,9 @@ openssl x509 -req -in "${INSTANCE_PATH}/client.csr" -text -days 30 \
 # Draupnir must be able to read the cert and key, to serve to the client
 chown draupnir "${INSTANCE_PATH}/client.key" "${INSTANCE_PATH}/client.crt"
 
+# Place socket in the instance directory
+echo "unix_socket_directories = '${INSTANCE_PATH}'" >> "${INSTANCE_PATH}/postgresql.conf"
+
 # Temporarily disable connections, until we have validated that the instance
 # has authentication correctly configured
 cat <<EOF >> "${INSTANCE_PATH}/postgresql.auto.conf"
@@ -93,7 +96,7 @@ listen_addresses = 'localhost'
 EOF
 chmod 640 "${INSTANCE_PATH}/postgresql.auto.conf"
 
-sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" start
+sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" -o "-p $PORT" -l "/var/log/postgresql-draupnir-instance/instance_$INSTANCE_ID" start
 
 # Verify that our instance has the correct authentication restrictions, so that
 # we can be sure it is not accessible to anyone not connecting in the expected
@@ -118,6 +121,6 @@ PGSSLMODE=verify-ca \
 
 rm -v "${INSTANCE_PATH}/postgresql.auto.conf"
 
-sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql/instance_$INSTANCE_ID" restart
+sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql-draupnir-instance/instance_$INSTANCE_ID" restart
 
 set +x

--- a/cmd/draupnir-destroy-instance
+++ b/cmd/draupnir-destroy-instance
@@ -31,7 +31,7 @@ INSTANCE_PATH="${ROOT}/instances/${ID}"
 
 set -x
 
-sudo -u postgres $PG_CTL -w -D "$INSTANCE_PATH" stop || true
+sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" stop || true
 sudo btrfs subvolume delete "$INSTANCE_PATH"
 
 set +x

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -143,7 +143,11 @@ local   all     all                     trust
 hostssl all     all     0.0.0.0/0       trust   clientcert=1
 EOF
 
-chown root:postgres "${UPLOAD_PATH}/pg_hba.conf"
+# Draupnir instances run as the draupnir-instance user
+find "${UPLOAD_PATH}" -user postgres -exec chown draupnir-instance {} \;
+find "${UPLOAD_PATH}" -group postgres -exec chgrp draupnir-instance {} \;
+
+chown root:draupnir-instance "${UPLOAD_PATH}/pg_hba.conf"
 chmod 640 "${UPLOAD_PATH}/pg_hba.conf"
 chattr +i "${UPLOAD_PATH}/pg_hba.conf"
 

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -118,12 +118,9 @@ do
   sleep 1
 done
 
-# Create a user
-sudo -u postgres createuser --port="$PORT" -d -r -s draupnir
-
 # Anonymise
 echo "Executing anonymisation script $ANON_FILE"
-sudo cat "$ANON_FILE" | sudo -u draupnir "$PSQL" -p "$PORT" --username=draupnir postgres
+sudo cat "$ANON_FILE" | sudo -u postgres "$PSQL" -p "$PORT"
 
 echo "Vacuum all the databases in the cluster"
 sudo -u postgres $VACUUMDB --all --port="$PORT" --jobs="$(nproc)"

--- a/spec/fixtures/bootstrap
+++ b/spec/fixtures/bootstrap
@@ -19,6 +19,12 @@ sudo -u postgres createuser draupnir
 sudo -u postgres psql -c "alter role draupnir password 'draupnir'"
 sudo -u draupnir psql draupnir -f /workspace/structure.sql
 
+# Create draupnir-instance user
+useradd draupnir-instance --system --shell /bin/false
+mkdir /var/log/postgresql-draupnir-instance
+chgrp draupnir-instance /var/log/postgresql-draupnir-instance
+chmod 775 /var/log/postgresql-draupnir-instance
+
 # Install self-signed certs
 cp /workspace/spec/fixtures/cert.pem /etc/ssl/certs/draupnir_cert.pem
 cp /workspace/spec/fixtures/key.pem /etc/ssl/certs/draupnir_key.pem

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -40,6 +40,14 @@ getent passwd draupnir >/dev/null || useradd --groups ssl-cert --create-home dra
 mkdir -p /data/{image_uploads,image_snapshots,instances}
 chown -R draupnir /data
 
+# create draupnir postgres instance user
+getent passwd draupnir-instance >/dev/null || useradd draupnir-instance
+
+# create draupnir postgres instance log directory
+mkdir /var/log/postgresql-draupnir-instance
+chgrp draupnir-instance /var/log/postgresql-draupnir-instance
+chmod 775 /var/log/postgresql-draupnir-instance
+
 # Ubuntu starts the DB after installation. Stop so that we can make a copy of the DB.
 pg_ctlcluster 11 main stop
 # wait for postgres to stop, so that the pid file disappears


### PR DESCRIPTION
To improve security and better isolate the instances we should change the user that the draupnir postgres instances run as. 

They currently run as `postgres` and this PR changes them to run as a new user called `draupnir-instance`.

We don't use the existing draupnir user as that user is used to run the draupnir api server which has read access to each instances client certificates. 