### PR TITLE
Only allow instance connections from non-superuser

### DIFF
--- a/cmd/draupnir-create-instance
+++ b/cmd/draupnir-create-instance
@@ -96,19 +96,30 @@ listen_addresses = 'localhost'
 EOF
 chmod 640 "${INSTANCE_PATH}/postgresql.auto.conf"
 
+# Provision a pg_ident.conf, and ensure that it can't be edited
+# The system username must match the CN provisioned in the client cert above.
+cat > "${INSTANCE_PATH}/pg_ident.conf" <<EOF
+# MAPNAME       SYSTEM-USERNAME                               PG-USERNAME
+draupnir        "Draupnir instance ${INSTANCE_ID} client"     draupnir
+EOF
+
+chown root:draupnir-instance "${INSTANCE_PATH}/pg_ident.conf"
+chmod 640 "${INSTANCE_PATH}/pg_ident.conf"
+chattr +i "${INSTANCE_PATH}/pg_ident.conf"
+
 sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" -o "-p $PORT" -l "/var/log/postgresql-draupnir-instance/instance_$INSTANCE_ID" start
 
 # Verify that our instance has the correct authentication restrictions, so that
 # we can be sure it is not accessible to anyone not connecting in the expected
 # manner.
 PGSSLMODE=disable \
-  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+  psql -h localhost -p "$PORT" -U draupnir -d postgres -Atc 'SELECT now();' \
     && die_and_stop "ERROR: Able to connect via non-TLS connection" \
     || echo "INFO: Not able to connect via non-TLS connection"
 
 PGSSLMODE=verify-ca \
   PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
-  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+  psql -h localhost -p "$PORT" -U draupnir -d postgres -Atc 'SELECT now();' \
     && die_and_stop "ERROR: Able to connect via TLS connection without client certificate" \
     || echo "INFO: Not able to connect without client certificate"
 
@@ -116,11 +127,32 @@ PGSSLMODE=verify-ca \
   PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
   PGSSLCERT="${INSTANCE_PATH}/client.crt" \
   PGSSLKEY="${INSTANCE_PATH}/client.key" \
-  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+  psql -h localhost -p "$PORT" -U draupnir -d postgres -Atc 'SELECT now();' \
     || die_and_stop "ERROR: Unable to connect via client-authenticated TLS connection"
+
+# Ensure that the user we're logging in with does not have superuser privileges.
+ISSUPERUSER=$(
+  PGSSLMODE=verify-ca \
+  PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
+  PGSSLCERT="${INSTANCE_PATH}/client.crt" \
+  PGSSLKEY="${INSTANCE_PATH}/client.key" \
+  psql -h localhost -p "$PORT" -U draupnir -d postgres -Atc 'SELECT usesuper FROM pg_user WHERE usename = CURRENT_USER;' \
+    || die_and_stop "ERROR: Unable to check superuser status"
+)
+[ "$ISSUPERUSER" == "f" ] || die_and_stop "ERROR: unexpected superuser status: '${ISSUPERUSER}'"
+
+# Ensure that it's not possible to login with another user, e.g. postgres,
+# which may have superuser privileges.
+PGSSLMODE=verify-ca \
+  PGSSLROOTCERT="${INSTANCE_PATH}/ca.crt" \
+  PGSSLCERT="${INSTANCE_PATH}/client.crt" \
+  PGSSLKEY="${INSTANCE_PATH}/client.key" \
+  psql -h localhost -p "$PORT" -U postgres -d postgres -Atc 'SELECT now();' \
+    && die_and_stop "ERROR: Able to connect with postgres user" \
+    || echo "INFO: Not able to connect with postgres user"
 
 rm -v "${INSTANCE_PATH}/postgresql.auto.conf"
 
-sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" -o "-i -p $PORT" -l "/var/log/postgresql-draupnir-instance/instance_$INSTANCE_ID" restart
+sudo -u draupnir-instance $PG_CTL -w -D "$INSTANCE_PATH" -o "-p $PORT" -l "/var/log/postgresql-draupnir-instance/instance_$INSTANCE_ID" restart
 
 set +x

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -118,17 +118,48 @@ do
   sleep 1
 done
 
-# Anonymise
+# Create a user to perform admin operations with
+sudo -u postgres createuser --port="$PORT" --createdb --createrole --superuser draupnir-admin
+
+# Create a user that will be used to connect to the instance, which does not
+# have superuser privileges, or the ability to create roles with these.
+# It's important to ensure that the user does not have superuser privileges, as
+# otherwise they will have access to read any file on the filesystem that the
+# user the process is running under has access to.
+sudo -u postgres createuser --port="$PORT" --createdb draupnir
+
+# Perform anonymisation. Do this before reassigning ownership, in case the
+# anonymisation script creates new objects owned by the draupnir-admin user.
 echo "Executing anonymisation script $ANON_FILE"
-sudo cat "$ANON_FILE" | sudo -u postgres "$PSQL" -p "$PORT"
+sudo cat "$ANON_FILE" | sudo -u postgres "$PSQL" -p "$PORT" --username=draupnir-admin postgres
 
 echo "Vacuum all the databases in the cluster"
 sudo -u postgres $VACUUMDB --all --port="$PORT" --jobs="$(nproc)"
+
+# Reassign the ownership of all objects (databases, tables, views etc.) from
+# the current user to the 'draupnir' user.
+# An assumption is made that the 'postgres' user is the superuser that was
+# created at initdb time, and therefore is skipped as it's not possible to
+# reassign all objects owned by this user. If this assumption does not hold,
+# then errors may be reported.
+pushd /tmp
+sudo -u postgres psql -U draupnir-admin -d postgres -p "$PORT" -v ON_ERROR_STOP=1 --echo-errors -qAtc "SELECT datname FROM pg_database WHERE datistemplate = false;" \
+  | while read -r database; do
+    sudo -u postgres psql -U draupnir-admin -d postgres -p "$PORT" -v ON_ERROR_STOP=1 --echo-errors -qAtc "SELECT usename FROM pg_user WHERE usename <> 'postgres';" \
+    | while read -r user; do
+      echo "Changing ownership of ${database}/${user}"
+      sudo -u postgres psql -U draupnir-admin -d "$database" -p "$PORT" -v ON_ERROR_STOP=1 --echo-errors -qAtc 'REASSIGN OWNED BY "'"${user}"'" TO draupnir;'
+  done
+done
+popd
 
 echo "Turning back on fsync and hot_standby wal level"
 sed -i \
   "s/wal_level = 'off'/wal_level = 'hot_standby'/; s/fsync = 'off'/fsync = 'on'/" \
   "${UPLOAD_PATH}/postgresql.conf"
+
+# The 'draupnir-admin' user is no longer required
+sudo -u postgres dropuser --port="$PORT" draupnir-admin
 
 sudo -u postgres $PG_CTL -D "$UPLOAD_PATH" -w stop
 sudo rm -f "${UPLOAD_PATH}/postmaster.pid"
@@ -136,11 +167,11 @@ sudo rm -f "${UPLOAD_PATH}/postmaster.opts"
 
 # Install our own pg_hba.conf, and ensure that it cannot be modified
 cat > "${UPLOAD_PATH}/pg_hba.conf" <<EOF
-# NOTE: The clientcert=1 option is essential - without this the Draupnir
-# instance will be accessible to anyone with knowledge of the host and port.
+# NOTE: The cert auth method is essential - without this the Draupnir instance
+# will be accessible to anyone with knowledge of the host and port.
 # Do not edit this unless you are absolutely certain of the consequences.
-local   all     all                     trust
-hostssl all     all     0.0.0.0/0       trust   clientcert=1
+local   all     all                             trust
+hostssl all     draupnir        0.0.0.0/0       cert    map=draupnir
 EOF
 
 # Draupnir instances run as the draupnir-instance user

--- a/cmd/draupnir/draupnir.go
+++ b/cmd/draupnir/draupnir.go
@@ -435,7 +435,7 @@ func setupClientEnvironment(config config.Config, instance models.Instance) erro
 	// Output enviroment variables that can be read by libpq:
 	// https://www.postgresql.org/docs/current/libpq-envars.html
 	fmt.Printf(
-		"export PGHOST=%s PGPORT=%d PGUSER=postgres PGPASSWORD='' PGDATABASE=%s PGSSLMODE=verify-ca PGSSLROOTCERT='%s' PGSSLCERT='%s' PGSSLKEY='%s'\n",
+		"export PGHOST=%s PGPORT=%d PGUSER=draupnir PGPASSWORD='' PGDATABASE=%s PGSSLMODE=verify-ca PGSSLROOTCERT='%s' PGSSLCERT='%s' PGSSLKEY='%s'\n",
 		instance.Hostname,
 		instance.Port,
 		database,

--- a/vagrant/example_db.sql
+++ b/vagrant/example_db.sql
@@ -1,11 +1,11 @@
 -- use createdb -o test test ?
 
-CREATE DATABASE test;
+CREATE user myapp_user WITH encrypted password '';
+GRANT ALL privileges ON DATABASE test TO myapp_user;
 
-CREATE user test WITH encrypted password '';
-GRANT ALL privileges ON DATABASE test TO test;
+CREATE DATABASE myapp OWNER myapp_user;
 
-\c test
+\c myapp
 
 CREATE TABLE users (
   id SERIAL PRIMARY KEY,
@@ -13,3 +13,5 @@ CREATE TABLE users (
   last_name TEXT,
   email TEXT UNIQUE NOT NULL
 );
+
+ALTER TABLE users OWNER TO myapp_user;


### PR DESCRIPTION
During the security review of the system concerns were raised about the
ability to connect to the Draupnir instances via the `postgres` user,
which has superuser privileges.
This is an issue because this user can use superuser-level functions to
do things like read file contents, and load extensions which may contain
malicious code.

To resolve this, make the following changes:
- Only allow connections from a `draupnir` user, which is added at
  image-finalisation time.
- Reassign all objects in all databases to the `draupnir` user, so that
  it has permissions to create, delete, alter etc all existing objects.
- Perform the instance verification checks with the `draupnir` user,
  rather than `postgres`.

Given that we now only allow connections from a single user, also change
the authentication in `pg_hba.conf` to enforce certificate
authentication, as opposed to trust but secured with certificate
authentication.