### PR TITLE
Allow better configuration of listen addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Changelog
 Unreleased
 ----------
 
-- Nothing
+**BREAKING CHANGES**
+- The meaning of the `--insecure` flag has changed. Use `--skip-verify` for the
+  old behaviour. `--insecure` now forces a non-TLS connection to the domain
+  specified in the local config file.
+- Remove the `port` and `insecure_port` configuration options, and replace them
+  with `listen_address` and `insecure_listen_address`. These are both optional
+  parameters, but at least one must be specified.
 
 4.1.0
 -----

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ Draupnir to boot. The variables are as follows:
 | `whitelist_reconcile_interval` | False    | If IP whitelisting is enabled, this is the interval at which Draupnir reconciles the IP address whitelist with what's in iptables, in order to clean up incorrect state. Uses the same format as `clean_interval`.
 | `use_x_forwarded_for`          | False    | Whether to use the `X-Forwarded-For` header when determining the real user IP address. See [documentation](#identification-of-user-ip-addresses).
 | `trusted_proxy_cidrs`          | False    | A list of CIDRs that will match your load balancer IP addresses. Example: `["10.32.0.0/16"]`. See [documentation](#identification-of-user-ip-addresses).
-| `http.port`                    | True     | The port that the HTTPS server will bind to.
-| `http.insecure_port`           | True     | The port that the HTTP server will bind to.
-| `http.tls_certificate`         | True     | The path to the TLS certificate file that the HTTPS server will use.
-| `http.tls_private_key`         | True     | The path to the TLS private key that the HTTPS server will use.
+| `http.listen_address`          | False    | The address and port that the HTTPS server will bind to.
+| `http.insecure_listen_address` | False    | The address and port that the HTTP server will bind to.
+| `http.tls_certificate`         | False    | The path to the TLS certificate file that the HTTPS server will use.
+| `http.tls_private_key`         | False    | The path to the TLS private key that the HTTPS server will use.
 | `oauth.redirect_url`           | True     | The redirect URL for the OAuth flow.
 | `oauth.client_id`              | True     | The OAuth client ID.
 | `oauth.client_secret`          | True     | The OAuth client secret.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install prerequisites:
 brew cask install virtualbox vagrant
 ```
 
-Build the Linux binary
+Build the Linux binary:
 ```
 make build-linux
 ```
@@ -52,13 +52,17 @@ Boot Vagrant VM:
 vagrant up
 ```
 
-Login and use Draupnir
+Login and use Draupnir:
 ```
 vagrant ssh
 $ sudo su -
-# eval $(/draupnir/draupnir.linux_amd64 --insecure new)
-# export PGHOST=localhost
-# psql
+# eval $(draupnir new)
+# psql -d myapp
+```
+
+After making changes to the code, to restart the server:
+```
+make build-linux && vagrant up --provision
 ```
 
 Tests

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -11,10 +11,10 @@ import (
 
 // HTTPConfig holds Draupnir's HTTP configuration
 type HTTPConfig struct {
-	Port               int    `toml:"port"`
-	InsecurePort       int    `toml:"insecure_port"`
-	TLSCertificatePath string `toml:"tls_certificate"`
-	TLSPrivateKeyPath  string `toml:"tls_private_key"`
+	SecureListenAddress   string `toml:"listen_address" required:"false"`
+	InsecureListenAddress string `toml:"insecure_listen_address" required:"false"`
+	TLSCertificatePath    string `toml:"tls_certificate" required:"false"`
+	TLSPrivateKeyPath     string `toml:"tls_private_key" required:"false"`
 }
 
 // OAuthConfig holds Draupnir's OAuth configuration

--- a/spec/fixtures/config.toml
+++ b/spec/fixtures/config.toml
@@ -10,8 +10,8 @@ min_instance_port = 16384
 max_instance_port = 20480
 
 [http]
-port = 8443
-insecure_port = 8080
+listen_address = "0.0.0.0:8443"
+insecure_listen_address = "127.0.0.1:8080"
 tls_certificate = "/etc/ssl/certs/draupnir_cert.pem"
 tls_private_key = "/etc/ssl/certs/draupnir_key.pem"
 

--- a/vagrant/draupnir.service
+++ b/vagrant/draupnir.service
@@ -6,6 +6,6 @@ After = network.target
 User = draupnir
 # Ensure that the directory that contains the iptables wrapper is at the front of the path
 Environment=PATH=/usr/lib/draupnir/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart = /draupnir/draupnir.linux_amd64 server
+ExecStart = /usr/local/bin/draupnir server
 Restart = always
 KillMode = process

--- a/vagrant/draupnir_client_config.toml
+++ b/vagrant/draupnir_client_config.toml
@@ -1,3 +1,11 @@
+# The vagrant instance has been provisioned to trust a self-signed CA
+# certificate that has been used to sign a `localhost` certificate.
+# Therefore the `--skip-verify` flag is not required when interacting with the
+# CLI.
 Domain = "localhost:8443"
+
+# Alternatively, uncomment this and use the `--insecure` flag
+# Domain = "localhost:8080"
+
 [Token]
   RefreshToken = "the_shared_secret"

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -13,8 +13,8 @@ use_x_forwarded_for = true
 trusted_proxy_cidrs = ["10.164.0.0/16"]
 
 [http]
-port = 8443
-insecure_port = 8080
+listen_address = "0.0.0.0:8443"
+insecure_listen_address = "127.0.0.1:8080"
 tls_certificate = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
 tls_private_key = "/etc/ssl/private/ssl-cert-snakeoil.key"
 

--- a/vagrant/draupnir_config.toml
+++ b/vagrant/draupnir_config.toml
@@ -15,8 +15,8 @@ trusted_proxy_cidrs = ["10.164.0.0/16"]
 [http]
 listen_address = "0.0.0.0:8443"
 insecure_listen_address = "127.0.0.1:8080"
-tls_certificate = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-tls_private_key = "/etc/ssl/private/ssl-cert-snakeoil.key"
+tls_certificate = "/var/draupnir/certificates/server.crt"
+tls_private_key = "/var/draupnir/certificates/server.key"
 
 [oauth]
 redirect_url = "https://example.com/oauth_callback"


### PR DESCRIPTION
e14b35c: Improve configuration of listen addresses

In the current state there is an 'insecure' port, which is bound to
localhost only, and a 'secure' port that listens on all interfaces.

The secure port only accepts requests that have negotiated a connection
over TLS (using the certificate/key pair provided to Draupnir), whereas
the insecure port uses plain HTTP.

There's a few issues with this:

1. It's not possible to disable either the secure or insecure ports.
2. It's not possible to make the insecure server available on any
   interface other than localhost, even if you have firewall rules that
   mitigate that being a potential issue.
3. It's not possible to specify the address (and therefore interface)
   that the secure server listens, making it available to anything on
   the machine.

In our configuration we would like to expose an insecure address only,
as this will be locked down and fronted by a cloud load balancer.

Therefore change the 'port' settings to represent full listen addresses,
for maximum configurability, and allow either to be disabled by not
specifying them in the configuration.

19ffdc1: CLI: Change insecure flag behaviour

Insecure now means that the CLI will connect via HTTP, whereas the new
`--skip-verify` flag will perform the old behaviour of disabling TLS
validation.

43c9149: Improve Vagrant provisioning script

- Symlink the Draupnir binary to a location in $PATH.
- Provide Draupnir with a trusted self-signed certificate to avoid the
  use of `--skip-verify`.
- When failing to execute, log the journal output for Draupnir, to avoid having to
  login to the instance to debug.
- Ignore unnecessary warnings when invoking `iptables -C`.
- Don't `chown` `/data` recursively, as this will break any existing
  instances.
- Restart the binary every time the provision script is run.

665a3ba: Update CHANGELOG


