### PR TITLE
Remove another place we log access tokens

### DIFF
--- a/pkg/server/api/middleware/error_handler.go
+++ b/pkg/server/api/middleware/error_handler.go
@@ -12,10 +12,7 @@ import (
 func NewErrorHandler(logger log.Logger) chain.TerminatingMiddleware {
 	return func(next chain.Handler) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			err := next(w, r)
-			if err != nil {
-				logger.With("http_request", r).Error(err.Error())
-			}
+			next(w, r)
 		}
 	}
 }

--- a/pkg/server/api/middleware/logger.go
+++ b/pkg/server/api/middleware/logger.go
@@ -62,6 +62,10 @@ func NewRequestLogger(logger log.Logger) chain.Middleware {
 				duration.Seconds(),
 			)
 
+			if err != nil {
+				scopedLogger = scopedLogger.With("error", err.Error())
+			}
+
 			scopedLogger.
 				With("status", recorder.Code).
 				With("duration", duration.Seconds()).


### PR DESCRIPTION
Sadly, we log them here too. Remove the error logging as it's already
included in the request log anyway, and we don't want to log tokens.