### PR TITLE
CI-1488: Downgrade Ubuntu version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,9 @@ jobs:
           paths: ['*.linux_amd64']
 
   integration:
-    machine:
-      image: ubuntu-2004:2022.04.2
+    machine: true # Setting this to true so we see it fail
+#    machine:
+#      image: ubuntu-2004:2022.04.2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,8 @@ jobs:
           paths: ['*.linux_amd64']
 
   integration:
-    machine: true
+    machine:
+      image: ubuntu-2004:2022.04.2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,8 @@ jobs:
           paths: ['*.linux_amd64']
 
   integration:
-    machine: true # Setting this to true so we see it fail
-#    machine:
-#      image: ubuntu-2004:2022.04.2
+    machine:
+      image: ubuntu-2004:2022.04.2
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This should help with installing an older version of ruby.

When I cut this branch from the master branch, even though they were up to date, the integration test was failing