### PR TITLE
quick: Update goreleaser to a more modern version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               echo "Version ${CURRENT_VERSION} is already released"
               exit 0
             fi
-            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
+            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.156.0/goreleaser_Linux_x86_64.tar.gz
             tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
             git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
             git tag "${CURRENT_VERSION}"


### PR DESCRIPTION
Currently, goreleaser is using an out of date version trying to build for darwin with the 386 arch, and failing to do so.

[v0.156.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.156.0) seems to address that