### PR TITLE
Update goreleaser brew syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     ldflags: -s -w -X github.com/gocardless/draupnir/pkg/version.Version={{.Version}} -X main.commit={{.Commit}}
 
 brews:
-  - github:
+  - tap:
       owner: gocardless
       name: homebrew-taps
     commit_author:


### PR DESCRIPTION
Since we are now using goreleaser 0.156.0, the following change was
introduced in 0.139.0

[PR link](https://github.com/goreleaser/goreleaser/pull/1649)
[Release](https://github.com/goreleaser/goreleaser/releases?q=0.139.0&expanded=true)