### PR TITLE
quick: Updating goreleaser to 1.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               echo "Version ${CURRENT_VERSION} is already released"
               exit 0
             fi
-            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.183.0/goreleaser_Linux_x86_64.tar.gz
+            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v1.10.2/goreleaser_Linux_x86_64.tar.gz
             tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
             git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
             git tag "${CURRENT_VERSION}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,10 +26,16 @@ nfpms:
     description: Databases on demand
     formats: [deb]
     bindir: /usr/local/bin
-    files:
-      "cmd/draupnir-create-instance": "/usr/local/bin/draupnir-create-instance"
-      "cmd/draupnir-destroy-image": "/usr/local/bin/draupnir-destroy-image"
-      "cmd/draupnir-destroy-instance": "/usr/local/bin/draupnir-destroy-instance"
-      "cmd/draupnir-finalise-image": "/usr/local/bin/draupnir-finalise-image"
-      "cmd/draupnir-start-image": "/usr/local/bin/draupnir-start-image"
-      "scripts/iptables": "/usr/lib/draupnir/bin/iptables"
+    contents:
+      - src: "cmd/draupnir-create-instance"
+        dst: "/usr/local/bin/draupnir-create-instance"
+      - src: "cmd/draupnir-destroy-image"
+        dst: "/usr/local/bin/draupnir-destroy-image"
+      - src: "cmd/draupnir-destroy-instance"
+        dst: "/usr/local/bin/draupnir-destroy-instance"
+      - src: "cmd/draupnir-finalise-image"
+        dst: "/usr/local/bin/draupnir-finalise-image"
+      - src: "cmd/draupnir-start-image"
+        dst: "/usr/local/bin/draupnir-start-image"
+      - src: "scripts/iptables"
+        dst: "/usr/lib/draupnir/bin/iptables"


### PR DESCRIPTION
Tested the config locally with that goreleaser version by running:
```sh
goreleaser check
```

Seems to like the current configuration. Making this update as npfm
files was deprecated

[Info on that](https://goreleaser.com/deprecations/?h=nfpms+files#nfpmsfiles)