### PR TITLE
Chore: Update dependabot configuration to not use private registry creds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,4 @@
 version: 2
-registries:
-  docker-registry-eu-gcr-io:
-    type: docker-registry
-    url: https://eu.gcr.io
-    username: _json_key
-    password: "${{secrets.DOCKER_REGISTRY_EU_GCR_IO_PASSWORD}}"
-  github-org-private:
-    type: git
-    url: https://github.com
-    username: x-access-token
-    password: "${{secrets.GIT_HUB_ROBOT_TOKEN}}"
-  github-org-ruby-private:
-    type: rubygems-server
-    url: https://rubygems.pkg.github.com/gocardless
-    username: gocardless-robot-readonly
-    password: "${{secrets.GIT_HUB_ROBOT_TOKEN}}"
 
 updates:
   - package-ecosystem: docker
@@ -31,9 +15,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     insecure-external-code-execution: allow
-    registries:
-      - github-org-private
-      - github-org-ruby-private
     versioning-strategy: auto
     allow:
       # Allow both direct and indirect updates for all packages

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gocardless/draupnir
 go 1.17
 
 require (
-	github.com/burntsushi/toml v0.3.0
+	github.com/BurntSushi/toml v0.3.0
 	github.com/coreos/go-iptables v0.6.0
 	github.com/getsentry/raven-go v0.2.1-0.20190619092523-5c24d5110e0e
 	github.com/google/jsonapi v0.0.0-20160922220230-925ebf213646

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gocardless/draupnir
 go 1.17
 
 require (
-	github.com/BurntSushi/toml v0.3.0
+	github.com/BurntSushi/toml v0.3.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/getsentry/raven-go v0.2.1-0.20190619092523-5c24d5110e0e
 	github.com/google/jsonapi v0.0.0-20160922220230-925ebf213646

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,9 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/burntsushi/toml v0.3.0 h1:7xSK9KkjYhUFUrcGkb57k/zXyeo8yshRmbFS2P1mQT0=
-github.com/burntsushi/toml v0.3.0/go.mod h1:tCq67G3LEDB9hykA6+KWl2FPEy0nPcvE8TTBhtOtdGs=
 github.com/certifi/gocertifi v0.0.0-20171105132559-a4ab0227d360 h1:mncIYTnditUQddapTftLSTGusm7hjdEWvKarvLlVi2M=
 github.com/certifi/gocertifi v0.0.0-20171105132559-a4ab0227d360/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/burntsushi/toml"
+	"github.com/BurntSushi/toml"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/burntsushi/toml"
+	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
No private repositories are used for dependabot, so we shouldn't
require access to private registries.

The go.mod change is made on the back of dependabot's suggestion so the file registers as valid. The way the toml module was required also had to be updated to match casing, as suggested by `go mod tidy`

Added screenshots of dependabot errors as those would hopefully go away once this PR gets merged in

For the env var issues we're seeing for ruby and docker, it's because I have set up dependabot to include private registries, but those env vars are only available on private repositories of GoCardless, not public ones, for security concerns.

The go.mod change is just a casing mismatch

<img width="2203" alt="Screen Shot 2022-08-04 at 11 11 37" src="https://user-images.githubusercontent.com/5496443/182822659-1bded5d5-94f4-4b2b-b336-5d77d11632bc.png">
<img width="2221" alt="Screen Shot 2022-08-04 at 11 11 42" src="https://user-images.githubusercontent.com/5496443/182822675-de32bb75-9c86-4a9e-b3f4-e08fb7d4d81b.png">
<img width="2224" alt="Screen Shot 2022-08-04 at 11 11 47" src="https://user-images.githubusercontent.com/5496443/182822681-def31b64-27d1-4ab2-868d-be58c7cb6cbd.png">

