### PR TITLE
Remove trailing mention of docker registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    registries:
-      - docker-registry-eu-gcr-io
 
   - package-ecosystem: bundler
     directory: "/"


### PR DESCRIPTION
I had incorrectly assumed this was a public registry, and thus did not
require a definition at the top of the file, but it turns out it's not