### PR TITLE
[Pdfr-43151] Fix failing tests for draupnir

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,6 @@ Draupnir.
 
 Common causes for an invalid refresh token are:
 - The user has revoked the application's third-party access in the Google
-  account dashboard.
+  account dashboard. 
 - The user is suspended via G Suite.
 - The user has been deleted.

--- a/README.md
+++ b/README.md
@@ -661,6 +661,6 @@ Draupnir.
 
 Common causes for an invalid refresh token are:
 - The user has revoked the application's third-party access in the Google
-  account dashboard. 
+  account dashboard.
 - The user is suspended via G Suite.
 - The user has been deleted.

--- a/cmd/draupnir-finalise-image
+++ b/cmd/draupnir-finalise-image
@@ -84,9 +84,12 @@ cat > "${UPLOAD_PATH}/pg_hba.conf" <<EOF
 # NOTE: The cert auth method is essential - without this the Draupnir instance
 # will be accessible to anyone with knowledge of the host and port.
 # Do not edit this unless you are absolutely certain of the consequences.
-local   all     all                             trust
-hostssl all     draupnir        0.0.0.0/0       cert    map=draupnir
+local   all             all                                     trust
+hostssl all             draupnir        127.0.0.1/32            cert    map=draupnir
+hostssl all             draupnir        ::1/128                 cert    map=draupnir
+hostssl all             draupnir        0.0.0.0/0               cert    map=draupnir
 EOF
+
 
 # Draupnir instances run as the draupnir-instance user
 find "${UPLOAD_PATH}" -user postgres -exec chown draupnir-instance {} \;


### PR DESCRIPTION
Need to upgrade dependencies but ran into test issues


Tests were failing with:

```
13 examples, 5 failures
Failed examples:
rspec ./spec/draupnir/instance_spec.rb:67 # /instances POST /instances creates the instance if given a ready image
rspec ./spec/draupnir/instance_spec.rb:117 # /instances GET /instances returns a JSON payload showing the instance
rspec ./spec/draupnir/instance_spec.rb:143 # /instances GET /instances/:id shows the given instance
rspec ./spec/draupnir/instance_spec.rb:184 # /instances GET /instances/:id returns the correct credentials for a given instance
rspec ./spec/draupnir/instance_spec.rb:208 # /instances DELETE /instances/:id deletes the instance and returns a 204
make: *** [Makefile:26: test-integration] Error 1
```

When container is built it is running tests towards it, it fails to create instance with error:

```
time="2024-10-30T14:03:18Z" level=info msg="Creating instance" client_ip_address=192.168.127.1 environment=test error="exit status 1" 

....

error: connection to server at \"localhost\" (::1), port 17007 failed: FATAL:  no pg_hba.conf entry for host \"::1\", user \"draupnir\", database \"postgres\", no encryption\n+ echo 'INFO: Not able to connect via non-TLS connection'

...
nINFO: Not able to connect without client certificate\nStopping instance\nwaiting for server to shut down.... done\nserver stopped\n"
```

so therefore we are met with 500 error:

`time="2024-10-30T14:03:18Z" level=info msg="POST /instances 500 0.790049" client_ip_address=192.168.127.1 duration=0.790048763 environment=test error="failed to create instance: exit status 1"`

I modified current pg_hba.conf: 

```
local   all     all                             trust
hostssl all     draupnir        0.0.0.0/0       cert    map=draupnir
```
to

```
local   all             all                                     trust
hostssl all             draupnir        127.0.0.1/32            cert    map=draupnir
hostssl all             draupnir        ::1/128                 cert    map=draupnir
hostssl all             draupnir        0.0.0.0/0               cert    map=draupnir
```

With these changes:
* We retain local trust for all users and dbs;
* Added explicit localhost rule that will allows local connections, also from ipv6 on local podman setup.
* All hostssl entries continue to use the cert auth with map=draupnir.


and the result = `13 examples, 0 failures`