### PR TITLE
[PDFR-43276]: update release workflow

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -118,7 +118,7 @@ jobs:
       - release-vars
     # Only release if we need to
     if: ${{ needs.need-release.outputs.release == 'true' }}
-    uses: gocardless/github-actions/.github/workflows/go-gorelease.yml@4763f2059fe34efe265ea7cb1ec5f9884c46169d
+    uses: gocardless/github-actions/.github/workflows/go-gorelease.yml@master
     with:
       release_notes: $(git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal | tee -a /tmp/release-notes)
       repository: ${{ github.repository }}

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,4 +1,8 @@
 name: build-integration
+
+env:
+  GO_VERSION: '1.17.3'
+
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]
@@ -20,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: ${{ env.GO_VERSION }}
       - run: make test
 
   rubocop:
@@ -38,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: ${{ env.GO_VERSION }}
       - run: go mod tidy
       - run: |
           if ! git diff --exit-code -- go.mod go.sum; then
@@ -51,7 +55,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: ${{ env.GO_VERSION }}
       - run: go mod download
       - run: env GOPROXY=off go build -mod=readonly ./...
 
@@ -61,7 +65,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: ${{ env.GO_VERSION }}
       - name: Build linux binary
         run: make build-production
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -70,27 +70,56 @@ jobs:
       - name: Run integration tests
         run: make test-integration
 
-  release:
-    if: contains('refs/heads/master', github.ref)
-    needs: integration
+  need-release:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - integration
+    # If we are on main, check if we need to release
+    if: ${{ contains('refs/heads/main', github.ref) }}
+    outputs:
+      release: ${{ steps.get_version.outputs.release }}
+      version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
         with:
-          go-version: 1.17.3
-      - name: Release
-        run: |-
+          fetch-depth: 0
+      # Check our DRAUPNIR_VERSION file against that in git, to see if we need to release
+      - name: Get version
+        id: get_version
+        run: |
           CURRENT_VERSION="v$(cat DRAUPNIR_VERSION)"
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
             echo "Version ${CURRENT_VERSION} is already released"
-            exit 0
+            echo "release=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${CURRENT_VERSION} can be released"
+            echo "release=true" >> $GITHUB_OUTPUT
           fi
-          curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v1.10.2/goreleaser_Linux_x86_64.tar.gz
-          tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
-          git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
-          git tag "${CURRENT_VERSION}"
-          git push --tags
-          /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes
+
+  # expose env vars to release job
+  release-vars:
+    needs: need-release
+    runs-on: ubuntu-latest
+    # Only run if we will need to release
+    if: ${{ needs.need-release.outputs.release == 'true' }}
+    outputs:
+      go_version: ${{ env.GO_VERSION }}
+    steps:
+      - run: echo "Exposing env vars"
+
+  release:
+    needs:
+      - need-release
+      - release-vars
+    # Only release if we need to
+    if: ${{ needs.need-release.outputs.release == 'true' }}
+    uses: gocardless/github-actions/.github/workflows/go-gorelease.yml@4763f2059fe34efe265ea7cb1ec5f9884c46169d
+    with:
+      release_notes: $(git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal | tee -a /tmp/release-notes)
+      repository: ${{ github.repository }}
+      go_version: ${{ needs.release-vars.outputs.go_version }}
+    secrets:
+      goreleaser_pat: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}
+      service_account: ${{ secrets.GCR_PUSHER_SERVICE_ACCOUNT }}
+      workload_identity_provider: ${{ secrets.KEYLESS_PROVIDER_NAME }}


### PR DESCRIPTION
### Problem

The current release workflow is failing with
``` 
⨯ release failed after 51s                 error=homebrew tap formula: failed to publish artifacts: PUT https://api.github.com/repos/gocardless/homebrew-taps/contents/Formula/draupnir.rb: 403 Resource not accessible by integration []
Error: Process completed with exit code 1.
```
indicating the default Github token doesn't have access to push to our homebrew repo. The [Draupnir formula](https://github.com/gocardless/homebrew-taps/blob/master/Formula/draupnir.rb) hasn't been updated in 2 years.

### Fix

Update the release workflow to use the goreleaser action and updated secrets. Followed the setup we have in the Utopia repo: https://github.com/gocardless/utopia/blob/main/.github/workflows/main.yml#L62-L101C1.